### PR TITLE
removed -K option and changed -k behavior for cli

### DIFF
--- a/src/js/__tests__/__snapshots__/cli-test.js.snap
+++ b/src/js/__tests__/__snapshots__/cli-test.js.snap
@@ -1,12 +1,3 @@
-exports[`getCliOpts produces an error when an option is not given to -k / --cache 1`] = `
-Array [
-  Array [
-    "lumo: option requires an argument: -k / --cache
-",
-  ],
-]
-`;
-
 exports[`print Functions printBanner should print the banner to stdout 1`] = `
 Array [
   Array [
@@ -31,9 +22,9 @@ Usage:  lumo [init-opt*] [main-opt] [arg*]
     -e, --eval string        Evaluate expressions in string; print non-nil values
     -c cp, --classpath cp    Use colon-delimited cp for source directories and
                              JARs
-    -K, --auto-cache         Create and use .planck_cache dir for cache
-    -k, --cache path         If dir exists at path, use it for cache
-    -q, --quiet              Quiet mode; doesn't print the banner initially
+    -k, --cache path         If dir exists at path, use it for cache, defaults to
+                             .lumo_cache; leave empty to skip cache
+    -q, --quiet              Quiet mode; doesn\'t print the banner initially
     -v, --verbose            Emit verbose diagnostic output
     -d, --dumb-terminal      Disable line editing / VT100 terminal control
     -s, --static-fns         Generate static dispatch function calls

--- a/src/js/__tests__/cli-test.js
+++ b/src/js/__tests__/cli-test.js
@@ -38,15 +38,15 @@ afterEach(() => {
 describe('getCliOpts', () => {
   it('parses single dash properties when they appear together', () => {
     Object.defineProperty(process, 'argv', {
-      value: ['', '', '-vK'],
+      value: ['', '', '-vq'],
     });
     startCLI();
     const [[parsedOpts]] = cljs.mock.calls;
 
     expect(parsedOpts.verbose).toBe(true);
     expect(parsedOpts.v).toBe(true);
-    expect(parsedOpts.K).toBe(true);
-    expect(parsedOpts['auto-cache']).toBe(true);
+    expect(parsedOpts.q).toBe(true);
+    expect(parsedOpts['quiet']).toBe(true);
   });
 
   it('adds scripts when -[ie] specified', () => {
@@ -90,24 +90,6 @@ describe('getCliOpts', () => {
 
     expect(parsedOpts._).toEqual(['foo.cljs']);
     expect(parsedOpts.repl).toBe(false);
-  });
-
-  it('produces an error when an option is not given to -k / --cache', () => {
-    const exit = process.exit;
-    process.exit = jest.fn();
-
-    const args = '-k';
-    Object.defineProperty(process, 'argv', {
-      value: ['', ''].concat(args.split(' ')),
-    });
-
-    startCLI();
-
-    expect(process.exit).toHaveBeenCalledWith(-1);
-    expect(process.stderr.write).toHaveBeenCalled();
-    expect(process.stderr.write.mock.calls).toMatchSnapshot();
-
-    process.exit = exit;
   });
 });
 

--- a/src/js/cli.js
+++ b/src/js/cli.js
@@ -18,8 +18,6 @@ export type CLIOptsType = {
   '?': boolean,
   repl: boolean,
   r: boolean,
-  'auto-cache': boolean,
-  K: boolean,
   quiet: boolean,
   q: boolean,
   'dumb-terminal': boolean,
@@ -66,8 +64,8 @@ Usage:  lumo [init-opt*] [main-opt] [arg*]
     -e, --eval string        Evaluate expressions in string; print non-nil values
     -c cp, --classpath cp    Use colon-delimited cp for source directories and
                              JARs
-    -K, --auto-cache         Create and use .planck_cache dir for cache
-    -k, --cache path         If dir exists at path, use it for cache
+    -k, --cache path         If dir exists at path, use it for cache, defaults to
+                             .lumo_cache; leave empty to skip cache
     -q, --quiet              Quiet mode; doesn't print the banner initially
     -v, --verbose            Emit verbose diagnostic output
     -d, --dumb-terminal      Disable line editing / VT100 terminal control
@@ -94,7 +92,6 @@ function getCLIOpts(): CLIOptsType {
       'verbose',
       'help',
       'repl',
-      'auto-cache',
       'quiet',
       'dumb-terminal',
       'static-fns',
@@ -109,7 +106,6 @@ function getCLIOpts(): CLIOptsType {
       i: 'init',
       e: 'eval',
       r: 'repl',
-      K: 'auto-cache',
       k: 'cache',
       q: 'quiet',
       d: 'dumb-terminal',
@@ -130,17 +126,15 @@ function processOpts(cliOpts: CLIOptsType): Object {
   const evl = opts.eval;
   const scripts = [];
 
-  if ({}.hasOwnProperty.call(opts, 'cache') ||
-      {}.hasOwnProperty.call(opts, 'auto-cache')) {
-    if (cache != null && util.isWhitespace(cache)) {
-      process.stderr.write('lumo: option requires an argument: -k / --cache\n');
-      process.exit(-1);
+  if ({}.hasOwnProperty.call(opts, 'cache')) {
+    if (util.isWhitespace(opts.cache)) {
+      opts.cache = null;
     }
-
-    const cachePath = cache || '.lumo_cache';
-    util.ensureDir(cachePath);
-
-    opts.cache = cachePath;
+  } else {
+    opts.cache = '.lumo_cache';
+  }
+  if (opts.cache) {
+    util.ensureDir(opts.cache);
   }
 
   // TODO: print classpath to stdout if `:verbose`


### PR DESCRIPTION
This removes the `-K` option. By default, it will use .lumo_cache dir for caching. To change cache dir, pass `-k [cache_dir]` option. If one wants to skip caching entirely, pass `-k` without a path.

This is for #16 