### PR TITLE
Add support for Windows-formatted class paths

### DIFF
--- a/src/js/__tests__/util-test.js
+++ b/src/js/__tests__/util-test.js
@@ -22,6 +22,12 @@ describe('srcPathsFromClasspathStrings', () => {
     expect(srcPathsFromClasspathStrings(['a:b', 'c:d', 'e'])).toEqual(['a', 'b', 'c', 'd', 'e']);
   });
 
+  if (isWindows) {
+    it('splits multiple paths with both ; and : separators, () => {
+      expect(srcPathsFromClasspathStrings(['a;b', 'c:d', 'e'])).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+  }
+
   it('expands ', () => {
     const ret = srcPathsFromClasspathStrings(['a:~/b', '~/c:~/d']);
 

--- a/src/js/__tests__/util-test.js
+++ b/src/js/__tests__/util-test.js
@@ -23,7 +23,7 @@ describe('srcPathsFromClasspathStrings', () => {
   });
 
   if (isWindows) {
-    it('splits multiple paths with both ; and : separators, () => {
+    it('splits multiple paths with both ; and : separators', () => {
       expect(srcPathsFromClasspathStrings(['a;b', 'c:d', 'e'])).toEqual(['a', 'b', 'c', 'd', 'e']);
     });
   }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -8,9 +8,12 @@ function expandPath(somePath: string): string {
   return somePath.startsWith('~') ? somePath.replace(/^~/, os.homedir) : somePath;
 }
 
+export const isWindows: boolean = /^Windows/.test(os.type());
+
 export function srcPathsFromClasspathStrings(cpStrs: string[]): string[] {
   return cpStrs.reduce((ret: string[], colonSepPaths: string) => {
-    const paths = colonSepPaths.split(':');
+    const sep = !isWindows ? ':' : ';';
+    const paths = colonSepPaths.split(sep);
 
     return ret.concat(paths.map(expandPath).map(path.normalize));
   }, []);
@@ -36,5 +39,3 @@ export function ensureArray<T>(maybeArray: T[] | T): T[] {
 export function isWhitespace(s: string): boolean {
   return s.trim() === '';
 }
-
-export const isWindows: boolean = /^Windows/.test(os.type());

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -12,7 +12,7 @@ export const isWindows: boolean = /^Windows/.test(os.type());
 
 export function srcPathsFromClasspathStrings(cpStrs: string[]): string[] {
   return cpStrs.reduce((ret: string[], colonSepPaths: string) => {
-    const sep = !isWindows ? ':' : ';';
+    const sep = !isWindows ? ':' : /;|:/;
     const paths = colonSepPaths.split(sep);
 
     return ret.concat(paths.map(expandPath).map(path.normalize));


### PR DESCRIPTION
In Windows, class paths are separated by `;` rather than `:`.  This uses the pre-existing Windows detection flag, `isWindows`, to determine which to use.