### PR TITLE
Generalized socket server

### DIFF
--- a/src/js/__tests__/repl-test.js
+++ b/src/js/__tests__/repl-test.js
@@ -311,8 +311,8 @@ describe('startREPL', () => {
       it('that are isolated by unique and incrementing ids', () => {
         startREPL({});
 
-        expect(handleConnection(socket).sessionId).toBe(1);
-        expect(handleConnection(socket).sessionId).toBe(2);
+        expect(handleConnection(socket)).toBe(1);
+        expect(handleConnection(socket)).toBe(2);
       });
     });
   });

--- a/src/js/cli.js
+++ b/src/js/cli.js
@@ -8,7 +8,6 @@ import startClojureScriptEngine from './cljs';
 import printLegal from './legal';
 import * as lumo from './lumo';
 import * as util from './util';
-import * as socketRepl from './socketRepl';
 import version from './version';
 
 type ScriptsType = [string, string][];
@@ -208,7 +207,6 @@ export default function startCLI(): void {
   const { args, cache, classpath, help, legal, mainNsName,
           mainScript, quiet, scripts } = opts;
   const autoCache = opts['auto-cache'];
-  const socketReplArgs = opts['socket-repl'];
 
   // if help, print help and bail
   if (help) {
@@ -246,20 +244,6 @@ export default function startCLI(): void {
 
   if (opts.repl && !quiet) {
     printBanner();
-  }
-
-  if (socketReplArgs != null) {
-    let [host, port] = socketReplArgs.split(':');
-
-    if (host != null && !isNaN(host)) {
-      [host, port] = [port, host];
-    }
-
-    socketRepl.open(parseInt(port, 10), host);
-    if (!quiet) {
-      process.stdout.write(
-        `Lumo socket REPL listening at ${host != null ? host : 'localhost'}:${port}.\n`);
-    }
   }
 
   return startClojureScriptEngine(opts);

--- a/src/js/cli.js
+++ b/src/js/cli.js
@@ -25,6 +25,7 @@ export type CLIOptsType = {
   cache?: string,
   classpath: string[],
   'socket-repl'?: string,
+  'accept-fn'?: string,
   mainNsName?: string,
   mainScript?: string,
   scripts: ScriptsType,
@@ -60,27 +61,28 @@ Usage:  lumo [init-opt*] [main-opt] [arg*]
   With no options or args, runs an interactive Read-Eval-Print Loop
 
   init options:
-    -i, --init path              Load a file or resource
-    -e, --eval string            Evaluate expressions in string; print
-                                 non-nil values
-    -c cp, --classpath cp        Use colon-delimited cp for source
-                                 directories and JARs
-    -K, --auto-cache             Create and use .planck_cache dir for cache
-    -k, --cache path             If dir exists at path, use it for cache
-    -q, --quiet                  Quiet mode; doesn't print the banner
-    -v, --verbose                Emit verbose diagnostic output
-    -d, --dumb-terminal          Disable line editing / VT100 terminal
-                                 control
-    -s, --static-fns             Generate static dispatch function calls
-    -n addr, --socket-repl addr  Enable a socket REPL where x is port or IP:port
+    -i, --init path                    Load a file or resource
+    -e, --eval string                  Evaluate expressions in string; print
+                                       non-nil values
+    -c cp, --classpath cp              Use colon-delimited cp for source
+                                       directories and JARs
+    -K, --auto-cache                   Create and use .planck_cache dir for cache
+    -k, --cache path                   If dir exists at path, use it for cache
+    -q, --quiet                        Quiet mode; doesn't print the banner
+    -v, --verbose                      Emit verbose diagnostic output
+    -d, --dumb-terminal                Disable line editing / VT100 terminal
+                                       control
+    -s, --static-fns                   Generate static dispatch function calls
+    -n addr, --socket-repl addr        Enable a socket REPL where x is port or IP:port
+    -A acceptFN, --accept-fn acceptFN  The function to run upon client connection
 
   main options:
-    -m ns-name, --main=ns-name   Call the -main function from a namespace
-                                 with args
-    -r, --repl                   Run a repl
-    path                         Run a script from a file or resource
-    -h, -?, --help               Print this help message and exit
-    -l, --legal                  Show legal info (licenses and copyrights)
+    -m ns-name, --main=ns-name         Call the -main function from a namespace
+                                       with args
+    -r, --repl                         Run a repl
+    path                               Run a script from a file or resource
+    -h, -?, --help                     Print this help message and exit
+    -l, --legal                        Show legal info (licenses and copyrights)
 
   The init options may be repeated and mixed freely, but must appear before
   any main option.
@@ -103,6 +105,7 @@ function getCLIOpts(): CLIOptsType {
     'v(verbose)',
     'd(dumb-terminal)',
     'n:(socket-repl)',
+    'A:(accept-fn)',
     's(static-fns)',
     'a(elide-asserts)',
     'm:(main)',
@@ -165,6 +168,9 @@ function getCLIOpts(): CLIOptsType {
         break;
       case 'n':
         ret['socket-repl'] = option.optarg;
+        break;
+      case 'A':
+        ret['accept-fn'] = option.optarg;
         break;
       case 's':
         ret['static-fns'] = true;

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -9,6 +9,7 @@ import path from 'path';
 import vm from 'vm';
 import * as lumo from './lumo';
 import startREPL from './repl';
+import * as socketRepl from './socketRepl';
 
 import type { CLIOptsType } from './cli';
 
@@ -216,26 +217,42 @@ function runMain(mainNS: string, args: string[]): void {
 }
 
 export default function startClojureScriptEngine(opts: CLIOptsType): void {
-  const { args, mainNsName, mainScript, repl, scripts } = opts;
+  const { args, mainNsName, mainScript, repl, scripts, quiet } = opts;
+  const socketReplArgs = opts['socket-repl'];
+
+  // The Socket Repl needs a CLJS Context to resolve the functions a user may pass in
+  // Instead of initializing in each if statement, we'll initialize once, then delete the
+  // context if it turns out we're not gonna use the context.
+  initClojureScriptEngine(opts);
+
+  if (socketReplArgs != null) {
+    let [host, port] = socketReplArgs.split(':');
+
+    if (host != null && !isNaN(host)) {
+      [host, port] = [port, host];
+    }
+
+    socketRepl.open(parseInt(port, 10), host);
+    if (!quiet) {
+      process.stdout.write(
+        `Lumo socket REPL listening at ${host != null ? host : 'localhost'}:${port}.\n`);
+    }
+  }
 
   if (scripts.length > 0) {
-    initClojureScriptEngine(opts);
     executeScripts(scripts);
   }
 
   if (mainScript) {
-    initClojureScriptEngine(opts);
     return executeScript(mainScript, 'path');
   }
 
   if (mainNsName) {
-    initClojureScriptEngine(opts);
     return runMain(mainNsName, args);
   }
 
   if (repl) {
     process.nextTick(() => {
-      initClojureScriptEngine(opts);
       execute('(require \'[lumo.repl :refer-macros [doc dir]])',
         'text', true, false, 'cljs.user');
     });
@@ -243,5 +260,6 @@ export default function startClojureScriptEngine(opts: CLIOptsType): void {
     return startREPL(opts);
   }
 
+  ClojureScriptContext = null;
   return undefined;
 }

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -225,6 +225,7 @@ export function runAcceptFN(fn: string, socket?: net$Socket): undefined {
 export default function startClojureScriptEngine(opts: CLIOptsType): void {
   const { args, mainNsName, mainScript, repl, scripts, quiet } = opts;
   const socketReplArgs = opts['socket-repl'];
+  const acceptFN = opts['accept-fn'];
 
   // The Socket Repl needs a CLJS Context to resolve the functions a user may pass in
   // Instead of initializing in each if statement, we'll initialize once, then delete the
@@ -238,7 +239,7 @@ export default function startClojureScriptEngine(opts: CLIOptsType): void {
       [host, port] = [port, host];
     }
 
-    socketRepl.open(parseInt(port, 10), host);
+    socketRepl.open(parseInt(port, 10), host, acceptFN);
     if (!quiet) {
       process.stdout.write(
         `Lumo socket REPL listening at ${host != null ? host : 'localhost'}:${port}.\n`);

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -216,6 +216,12 @@ function runMain(mainNS: string, args: string[]): void {
   ClojureScriptContext.lumo.repl.run_main.apply(null, [mainNS, ...args]);
 }
 
+export function runAcceptFN(fn: string, socket?: net$Socket): undefined {
+  ClojureScriptContext.lumo.repl.run_accept_fn.call(null, fn, socket);
+
+  return undefined;
+}
+
 export default function startClojureScriptEngine(opts: CLIOptsType): void {
   const { args, mainNsName, mainScript, repl, scripts, quiet } = opts;
   const socketReplArgs = opts['socket-repl'];

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -38,7 +38,7 @@ function openRepl(socket: net$Socket): void {
 }
 
 // Calls the `accept` function on the socket and handles the socket lifecycle
-function handleConnection(socket: net$Socket, accept: AcceptFn): void {
+function handleConnection(socket: net$Socket, accept: AcceptFn): number {
   accept(socket);
 
   // The index needs to be unique for the socket server, but not for anyone else.
@@ -50,6 +50,8 @@ function handleConnection(socket: net$Socket, accept: AcceptFn): void {
   sockets[sessionCount] = socket;
 
   sessionCount += 1;
+
+  return sessionCount;
 }
 
 export function close(): void {

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -4,6 +4,7 @@ import net from 'net';
 import readline from 'readline';
 import { createBanner } from './cli';
 import { createSession, deleteSession, prompt, processLine } from './repl';
+import { runAcceptFN } from './cljs';
 
 let socketServer: ?net$Server = null;
 const sockets: net$Socket[] = [];
@@ -39,6 +40,7 @@ function openRepl(socket: net$Socket): void {
 
 // Calls the `accept` function on the socket and handles the socket lifecycle
 function handleConnection(socket: net$Socket, accept: AcceptFn): number {
+  runAcceptFN("hello.world/hello", socket);
   accept(socket);
 
   // The index needs to be unique for the socket server, but not for anyone else.

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -3,7 +3,7 @@
 import net from 'net';
 import readline from 'readline';
 import { createBanner } from './cli';
-import { createSession, deleteSession, prompt, processLine, unhookOutputStreams } from './repl';
+import { createSession, deleteSession, prompt, processLine } from './repl';
 
 import type { REPLSession } from './repl';
 
@@ -11,6 +11,7 @@ let socketServer: ?net$Server = null;
 const sockets: net$Socket[] = [];
 
 let sessionCount = 0;
+type AcceptFn = <T>(socket: net$Socket) => T;
 
 // Default socket accept function. This opens a repl and handles the readline and repl lifecycle
 function openRepl(socket: net$Socket): REPLSession {
@@ -41,11 +42,11 @@ function openRepl(socket: net$Socket): REPLSession {
 }
 
 // Calls the `accept` function on the socket and handles the socket lifecycle
-function handleConnection(socket: net$Socket, accept: Function): void {
+function handleConnection(socket: net$Socket, accept: AcceptFn): void {
   accept(socket);
 
-  // The index needs to be unique for the socket server, but not for anyone else. For that reason we're
-  // using a module global `sessionCount` variable
+  // The index needs to be unique for the socket server, but not for anyone else.
+  // For that reason we're using a module global `sessionCount` variable
   socket.on('close', () => {
     delete sockets[sessionCount];
   });
@@ -69,7 +70,7 @@ export function close(): void {
   socketServer.close();
 }
 
-export function open(port: number, host?: string = 'localhost', accept?: Function = openRepl): void {
+export function open(port: number, host?: string = 'localhost', accept?: AcceptFn = openRepl): void {
   socketServer = net.createServer((socket: net$Socket) => handleConnection(socket, accept));
   socketServer.listen(port, host);
 

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -56,8 +56,6 @@ function handleConnection(socket: net$Socket, accept: Function): void {
 }
 
 export function close(): void {
-  unhookOutputStreams();
-
   if (!socketServer) {
     return;
   }

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -5,16 +5,14 @@ import readline from 'readline';
 import { createBanner } from './cli';
 import { createSession, deleteSession, prompt, processLine } from './repl';
 
-import type { REPLSession } from './repl';
-
 let socketServer: ?net$Server = null;
 const sockets: net$Socket[] = [];
 
 let sessionCount = 0;
-type AcceptFn = <T>(socket: net$Socket) => T;
+type AcceptFn = (socket: net$Socket) => void;
 
 // Default socket accept function. This opens a repl and handles the readline and repl lifecycle
-function openRepl(socket: net$Socket): REPLSession {
+function openRepl(socket: net$Socket): void {
   const rl = readline.createInterface({
     input: socket,
     output: socket,
@@ -37,8 +35,6 @@ function openRepl(socket: net$Socket): REPLSession {
   // $FlowIssue - output missing from readline$Interface
   rl.output.write(createBanner());
   prompt(rl, false, 'cljs.user');
-
-  return session;
 }
 
 // Calls the `accept` function on the socket and handles the socket lifecycle

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -12,7 +12,7 @@ const sockets: net$Socket[] = [];
 
 let sessionCount = 0;
 
-// XXX Whichever function is set to handle the socket should cleanup on the socket's `close` event
+// Default socket accept function. This opens a repl and handles the readline and repl lifecycle
 function openRepl(socket: net$Socket): REPLSession {
   const rl = readline.createInterface({
     input: socket,
@@ -40,12 +40,12 @@ function openRepl(socket: net$Socket): REPLSession {
   return session;
 }
 
-// This takes in a socket, and handles the socket life cycle
+// Calls the `accept` function on the socket and handles the socket lifecycle
 function handleConnection(socket: net$Socket, accept: Function): void {
   accept(socket);
 
-  // ??? Do we actually care what session id the repl returns?
-  // AAA Let's go with no.
+  // The index needs to be unique for the socket server, but not for anyone else. For that reason we're
+  // using a module global `sessionCount` variable
   socket.on('close', () => {
     delete sockets[sessionCount];
   });

--- a/src/js/socketRepl.js
+++ b/src/js/socketRepl.js
@@ -10,7 +10,7 @@ let socketServer: ?net$Server = null;
 const sockets: net$Socket[] = [];
 
 let sessionCount = 0;
-type AcceptFn = (socket: net$Socket) => void;
+type AcceptFn = (socket: net$Socket) => void | string;
 
 // Default socket accept function. This opens a repl and handles the readline and repl lifecycle
 function openRepl(socket: net$Socket): void {
@@ -39,9 +39,12 @@ function openRepl(socket: net$Socket): void {
 }
 
 // Calls the `accept` function on the socket and handles the socket lifecycle
-function handleConnection(socket: net$Socket, accept: AcceptFn): number {
-  runAcceptFN("hello.world/hello", socket);
-  accept(socket);
+function handleConnection(socket: net$Socket, accept: AcceptFn, userAccept?: boolean): number {
+  if (typeof(accept)==='string') {
+    runAcceptFN(accept, socket);
+  } else {
+    accept(socket);
+  }
 
   // The index needs to be unique for the socket server, but not for anyone else.
   // For that reason we're using a module global `sessionCount` variable

--- a/tst/hello/world.cljs
+++ b/tst/hello/world.cljs
@@ -1,4 +1,4 @@
 (ns hello.world)
 
 (defn hello [socket]
-  (js/console.log socket))
+  (.end socket "\nHello friend.\n\n"))

--- a/tst/hello/world.cljs
+++ b/tst/hello/world.cljs
@@ -1,0 +1,4 @@
+(ns hello.world)
+
+(defn hello [socket]
+  (js/console.log socket))


### PR DESCRIPTION
I'd love to generalize the socket server so that it could facilitate communication to more than just a repl. To make this work, I've generalized the `socketRepl.js` file to allow for an `accept` function to be passed to it.

The accept function needs to take a single argument, which is the socket to listen on.