### PR TITLE
hide diff results for yarn.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+
+yarn.lock binary


### PR DESCRIPTION
This piece of code should hide diffing for that file, more: https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes