### PR TITLE
Add lumo.repl/get-arglists

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -46,7 +46,8 @@
         :js-env :node
         :namespaces #{'lumo.js-deps-tests 'lumo.repl-tests}
         :cljs-opts {:parallel-build true}
-        :exit? exit?))))
+        :exit? exit?
+        :ids #{"lumo_test/test_suite"}))))
 
 (deftask auto-test []
   (comp

--- a/src/cljs/snapshot/lumo/common.cljs
+++ b/src/cljs/snapshot/lumo/common.cljs
@@ -8,12 +8,12 @@
 
 (def ^:private ^:const JSON_EXT ".json")
 
-(defn- transit-json->cljs
+(defn transit-json->cljs
   [json]
   (let [rdr (transit/reader :json)]
     (transit/read rdr json)))
 
-(defn- cljs->transit-json
+(defn cljs->transit-json
   [x]
   (let [wtr (transit/writer :json)]
     (transit/write wtr x)))

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -811,6 +811,17 @@
   (deps/index-upstream-foreign-libs))
 
 ;; --------------------
+;; Introspection
+
+(defn ^:export get-arglists
+  "Return the argument lists for the given symbol as string."
+  [s]
+  (when-let [var (some->> s repl-read-string first (resolve-var @env/*compiler*))]
+    (if-not (:macro var)
+      (:arglists var)
+      (-> var :meta :arglists second))))
+
+;; --------------------
 ;; Autocompletion
 
 (defn- completion-candidates-for-ns

--- a/test/lumo/repl_tests.cljs
+++ b/test/lumo/repl_tests.cljs
@@ -72,3 +72,8 @@
 (deftest test-root-resource
   (is (= (lumo/root-resource 'foo-bar-baz) "/foo_bar_baz"))
   (is (= (lumo/root-resource 'foo.bar.baz) "/foo/bar/baz")))
+
+(deftest test-get-arglists
+  (is (= (lumo/get-arglists "whatever") nil))
+  (is (= (lumo/get-arglists "map") '([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])))
+  (is (= (lumo/get-arglists "when") '([test & body]))))

--- a/test/lumo/repl_tests.cljs
+++ b/test/lumo/repl_tests.cljs
@@ -1,9 +1,11 @@
 (ns lumo.repl-tests
   (:require [cljs.nodejs :as node]
-            [cljs.test :refer [deftest is testing]]
-            [lumo.repl :as lumo]))
+            [cljs.test :refer [deftest is testing use-fixtures]]
+            [lumo.repl :as lumo]
+            [lumo.common :as common]
+            [lumo.test-util :as test-util]))
 
-(set! (. js/global -$$LUMO_GLOBALS) #js {:getParinfer #(node/require "parinfer")})
+(use-fixtures :once test-util/with-parinfer test-util/with-cache)
 
 (deftest test-is-readable?
   (is (false? (lumo/is-readable? "(")))

--- a/test/lumo/test_util.cljs
+++ b/test/lumo/test_util.cljs
@@ -1,0 +1,35 @@
+(ns lumo.test-util
+  (:require [cljs.nodejs :as node]
+            [cljs.js :as cljs]
+            [lumo.common :as common])
+  (:require-macros [cljs.env.macros :as env]))
+
+(defn with-parinfer [f]
+  (set! (. js/global -$$LUMO_GLOBALS) #js {:getParinfer #(node/require "parinfer")})
+  (f)
+  (set! (. js/global -$$LUMO_GLOBALS) nil))
+
+(def fs (js/require "fs"))
+
+(defn read-file-sync [file-path & [encoding-or-opts]]
+  (try
+    (.readFileSync fs file-path encoding-or-opts)
+    (catch :default e nil)))
+
+;; For the cache source folder, the test id needs to become:
+;;   lumo_test/test_suite => test_suite.out/
+(def cljs-core-cache-path "test_suite.out/cljs/core.cljs.cache.json")
+(def cljs-core-macros-cache-path "test_suite.out/cljs/core$macros.cljc.cache.json")
+
+(defn with-cache [f]
+  (let [st (cljs/empty-state)]
+    (cljs/load-analysis-cache! st 'cljs.core
+                               (-> cljs-core-cache-path
+                                   read-file-sync
+                                   common/transit-json->cljs))
+    (cljs/load-analysis-cache! st 'cljs.core$macros
+                               (-> cljs-core-macros-cache-path
+                                   read-file-sync
+                                   common/transit-json->cljs))
+    (env/with-compiler-env st
+      (f))))


### PR DESCRIPTION
Hi Antonio, I added this utility function because `inf-clojure` needs it.

Oddily, the tests are not working on my machine, but the same in the `yarn dev` repl works:

```
cljs.user=> (require '[cljs.test :as test :refer-macros [is]])
nil
cljs.user=> (is (= (lumo/get-arglists "cljs.core/map") '([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])))
true
```

I could not figure out why, but `lumo.repl/resolve-var` calls to `cljs.analyzer` both fail with `#object[Error Error: No protocol method IDeref.-deref defined for type null: ]`. Again, this happenes only in `boot test`, maybe it is running with another version of ClojureScript.

In any case, I'll be waiting for your comments :wink: 