### PR TITLE
No longer print returned nil if using -e command line flag

### DIFF
--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -174,7 +174,7 @@ export function execute(
 }
 
 function executeScript(code: string, type: string): void {
-  return execute(code, type, type !== 'path');
+  return execute(code, type, type !== 'path', false);
 }
 
 export function getCurrentNamespace(): string {


### PR DESCRIPTION
As requested in issue #108