### PR TITLE
Add a placeholder bin/lumo script

### DIFF
--- a/packages/lumo/bin/lumo
+++ b/packages/lumo/bin/lumo
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Placeholder script. This gets overwritten by scripts/npm_install.js
+
+echo "FATAL: Lumo installation failed to complete. Please try re-installing (npm install -g lumo-cljs)." >&2
+exit 1


### PR DESCRIPTION
Currently installation fails, because npm tries to chmod +x bin/lumo,
and there's nothing there. This adds a placeholder that also gives
the user a helpful message should it happen that their installation
fails halfway.

Fixes #134