### PR TITLE
Namespaced keyword

### DIFF
--- a/src/cljs/bundled/lumo/analyzer.cljs
+++ b/src/cljs/bundled/lumo/analyzer.cljs
@@ -217,7 +217,7 @@
                path    (.-src res)
                cache   nil #_(when (:cache-analysis opts)
                          (cache-file res ns-info output-dir))]
-           (when-not (get-in @env/*compiler* [::namespaces (:ns ns-info) :defs])
+           (when-not (get-in @env/*compiler* [::ana/namespaces (:ns ns-info) :defs])
              (if (or skip-cache (not cache) (requires-analysis? res output-dir))
                (binding [ana/*cljs-ns* 'cljs.user
                          ana/*cljs-file* path


### PR DESCRIPTION
I think ::namespaces here was supposed to refer to :cljs.analyzer/namespaces