### PR TITLE
Bundle aot.js.map files

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -10,7 +10,7 @@
                  [org.clojure/test.check      "0.10.0-alpha2" :scope "test"]
                  [com.cognitect/transit-clj   "0.8.300" :scope "test"]
                  [com.cemerick/piggieback     "0.2.2"   :scope "test"]
-                 [adzerk/boot-cljs            "2.1.2"   :scope "test"]
+                 [adzerk/boot-cljs            "2.1.3"   :scope "test"]
                  [crisptrutski/boot-cljs-test "0.3.3"   :scope "test"]
                  [org.clojure/tools.nrepl     "0.2.13"  :scope "test"]
                  [weasel                      "0.7.0"   :scope "test"]

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -37,6 +37,7 @@ function deflate(fname) {
 const outputPath = `build/${/^Windows/.test(os.type()) ? 'lumo.exe' : 'lumo'}`;
 const resources = getDirContents('target').filter(
   fname =>
+    fname.endsWith('.aot.js.map') ||
     !fname.endsWith('main.js') &&
     !fname.endsWith('bundle.js') &&
     !fname.endsWith('bundle.min.js') &&


### PR DESCRIPTION
...so that the Google Closure Compiler can safely generate source maps.