### PR TITLE
process stdin as buffers instead of strings

### DIFF
--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -350,16 +350,16 @@ function runMain(mainNS: string, args: string[]): void {
 }
 
 function processStdin(): void {
-  let code = '';
-  process.stdin.on('data', (chunk: string) => {
-    code += chunk;
+  const chunks = [];
+  process.stdin.on('data', (chunk: Buffer) => {
+    chunks.push(chunk);
   });
   process.stdin.on('error', () => {
     process.stderr.write('Error processing stdin.\n');
     process.exit(1);
   });
   process.stdin.on('end', () => {
-    executeScript(code, 'text');
+    execute(Buffer.concat(chunks).toString(), 'text', true, false);
   });
 }
 


### PR DESCRIPTION
As of current lumo version running `echo "(println \"Hello World\")" | lumo -` causes the the code to run but with a EOF stacktrace after it
```
Hello World
EOF while reading.
	 (new)
	 Function.cljs.core.ex_info.cljs$core$IFn$_invoke$arity$3 (NO_SOURCE_FILE <embedded>:1923:72)
	 Function.cljs.core.ex_info.cljs$core$IFn$_invoke$arity$2 (NO_SOURCE_FILE <embedded>:1922:449)
	 Function.cljs.tools.reader.impl.errors.throw_ex.cljs$core$IFn$_invoke$arity$variadic (NO_SOURCE_FILE <embedded>:2111:303)
	 Function.cljs.tools.reader.impl.errors.eof_error.cljs$core$IFn$_invoke$arity$variadic (NO_SOURCE_FILE <embedded>:2120:138)
	 Object.cljs.tools.reader.impl.errors.throw_eof_error (NO_SOURCE_FILE <embedded>:2156:307)
	 Object.cljs.tools.reader.read_STAR__internal (NO_SOURCE_FILE <embedded>:2285:106)
	 Function.cljs.tools.reader.read_STAR_.cljs$core$IFn$_invoke$arity$6 (NO_SOURCE_FILE <embedded>:2288:111)
	 Function.cljs.tools.reader.read.cljs$core$IFn$_invoke$arity$2 (NO_SOURCE_FILE <embedded>:2295:442)
	 Object.lumo.repl.repl_read_string (NO_SOURCE_FILE <embedded>:6458:114)
```

According to https://millermedeiros.github.io/mdoc/examples/node_api/doc/streams.html#Event
```
The 'data' event emits either a Buffer (by default) or a string if setEncoding() was used.
```
So I tried to add `process.stdin.setEncoding('utf8');` without luck. This fix is mostly copy paste of my initial pull request, instead of `const` I included `let`.
```
[hlolli@localhost lumo]$ echo "(println \"Hello World\")" | node target/bundle.js -k lumo-cache -c target -d -
Hello World
[hlolli@localhost lumo]$ 
```