### PR TITLE
Try to improve the compiler

### DIFF
--- a/src/cljs/bundled/lumo/closure.cljs
+++ b/src/cljs/bundled/lumo/closure.cljs
@@ -452,9 +452,7 @@
       (lcomp/compile-file file out-file opts
         (fn [res]
           (if (:error res)
-            (do
-              (println "crlh " res)
-              (cb res))
+            (cb res)
             (cb (compiled-file res))))))
     (let [path file]
       (binding [ana/*cljs-file* path]
@@ -855,7 +853,7 @@
                (util/measure (and compiler-stats (:verbose opts))
                  (str "Compile " (:ns ns-info))
                  (-compile (or (:source-file ns-info)
-                             (:source-forms ns-info))
+                               (:source-forms ns-info))
                                         ; - ns-info -> ns -> cljs file relpath -> js relpath
                    (merge opts {:output-file (lcomp/rename-to-js (util/ns->relpath (:ns ns-info)))})
                    cb)))

--- a/src/cljs/bundled/lumo/closure.cljs
+++ b/src/cljs/bundled/lumo/closure.cljs
@@ -1255,7 +1255,7 @@
   to the specified base file."
   [^File base input]
   (let [base-path  (util/path-seq (js/$$LUMO_GLOBALS.path.resolve base))
-        input-path (util/path-seq (js/$$LUMO_GLOBALS.path.resolve (deps/-url input)))
+        input-path (util/path-seq (js/$$LUMO_GLOBALS.path.resolve (util/path (deps/-url input))))
         count-base (count base-path)
         common     (count (take-while true? (map #(= %1 %2) base-path input-path)))
         prefix     (repeat (- count-base common 1) "..")]

--- a/src/cljs/bundled/lumo/compiler.cljs
+++ b/src/cljs/bundled/lumo/compiler.cljs
@@ -168,7 +168,8 @@
       env/*compiler*
       source
       nil
-      (assoc opts :verbose false)
+      (merge opts {:verbose false
+                   :analyze-deps false}) ;; fixes #245 and ^:const error in #239
       (fn [{:keys [value error] :as m}]
         (if error
           (cb {:error error})

--- a/src/cljs/bundled/lumo/compiler.cljs
+++ b/src/cljs/bundled/lumo/compiler.cljs
@@ -278,8 +278,8 @@
                     (with-core-cljs opts (fn [] (lana/analyze-file src-file opts))))
                   ns-info)))
             (catch :default e
-              (throw (ex-info (str "failed compiling file:" src) {:file src} e))))
-          (throw (ex-info (str "The file " src " does not exist.") {:file src})))))))
+              (cb {:error (ex-info (str "failed compiling file:" src) {:file src} e)})))
+          (cb {:error (ex-info (str "The file " src " does not exist.") {:file src})}))))))
 
 (defn compile-root
   "Looks recursively in src-dir for .cljs files and compiles them to

--- a/src/cljs/bundled/lumo/compiler.cljs
+++ b/src/cljs/bundled/lumo/compiler.cljs
@@ -176,23 +176,10 @@
           (let [sm-data (when comp/*source-map-data* @comp/*source-map-data*)
                 ret     (merge
                           (lana/parse-ns src)
-                          {:file dest
-                           ;; :requires (if (= ns-name 'cljs.core)
-                           ;;             (set (vals deps))
-                           ;;             (cond-> (conj (set (vals deps)) 'cljs.core)
-                           ;;               (get-in @env/*compiler* [:options :emit-constants])
-                           ;;               (conj ana/constants-ns-sym)))
-                           }
-                          #_{:ns         (or ns-name 'cljs.user)
-                           :macros-ns  (:macros-ns opts)
-                           :provides   [ns-name]
-                           :requires   (if (= ns-name 'cljs.core)
-                                         (set (vals deps))
-                                         (cond-> (conj (set (vals deps)) 'cljs.core)
-                                           (get-in @env/*compiler* [:options :emit-constants])
-                                           (conj ana/constants-ns-sym)))
-                           :file        dest
-                           :source-file src}
+                          ;; All the necessary keys like :requires, :provides,
+                          ;; etc... are already returned (as JavaScriptFile) by
+                          ;; the above lana/parse-ns
+                          {:file dest}
                           (when sm-data
                             {:source-map (:source-map sm-data)}))]
             (when (and sm-data (= :none (:optimizations opts)))

--- a/src/cljs/bundled/lumo/compiler.cljs
+++ b/src/cljs/bundled/lumo/compiler.cljs
@@ -228,7 +228,7 @@
                   (emit-source src dest ext opts
                     (fn [ret]
                       (if (:error ret)
-                        (cb {:error (:error ret)})
+                        (cb ret)
                         (do
                           (util/set-last-modified dest (util/last-modified src))
                           (cb ret)))))))))))))
@@ -279,7 +279,7 @@
                     (swap! env/*compiler* update-in [::ana/namespaces] dissoc ns))
                   (compile-file* src-file dest-file opts
                     (fn [ret]
-                      (when comp/*recompiled*
+                      (when (and (not (:error ret)) comp/*recompiled*)
                         (swap! comp/*recompiled* conj ns))
                       (cb ret))))
                 (do


### PR DESCRIPTION
Here we go :dagger: 

Some inspiration for the Lumo report:

```clojure
(do (util/debug-prn "\n- Lumo Build Report")
    (let [[js-files errors] (split-with #(instance? JavaScriptFile %) sources)]
      (print "  [Compiled]")
      (if (seq js-files)
        (util/debug-prn (->> js-files (map :url) (interleave (repeat "\n    ")) (string/join)))
        (util/debug-prn "-"))
      (util/debug-prn "  [Failures]" (->> errors
                                          (map :error)
                                          (remove nil?)
                                          (map #(str (.-message %) ": " (.-stack (.-cause %))))
                                          (interleave (repeat "\n    "))
                                          (string/join)))))
```


The patches below do not solve the `core.async` problem, which looks like cannot just find the `ioc_macro.clj` in the file system:

```
[Failures] 
    Could not require cljs.core.async.impl.ioc-macros in file cljs/core/async/macros.clj: Error: failed compiling file:src/cqrs_cloud/event_store.cljs
    at new cljs.core.ExceptionInfo (<embedded>:1931:47)
    at Function.cljs.core.ex_info.cljs$core$IFn$_invoke$arity$3 (<embedded>:1934:200)
    at evalmachine.<anonymous>:620:25
    at Function.lumo.compiler.compile_file.cljs$core$IFn$_invoke$arity$4 (evalmachine.<anonymous>:627:4)
    at Object.lumo$closure$compile_file [as compile_file] (evalmachine.<anonymous>:1467:35)
    at evalmachine.<anonymous>:1629:21
    at Object.lumo$closure$_compile [as _compile] (evalmachine.<anonymous>:1270:122)
    at evalmachine.<anonymous>:2252:21
    at Function.lumo.closure.map_async.cljs$core$IFn$_invoke$arity$4 (evalmachine.<anonymous>:2103:98)
    at evalmachine.<anonymous>:2100:31
```