### PR TITLE
Add callback to lumo.build.api/build

### DIFF
--- a/src/test/lumo/lumo/build_api_tests.cljs
+++ b/src/test/lumo/lumo/build_api_tests.cljs
@@ -159,7 +159,7 @@
   (let [out (path/join (test/tmp-dir) "cljs-1537-test-out")
         root "src/test/cljs_build"]
     (test/delete-out-files out)
-    (closure/build
+    (build/build
       (build/inputs
         (path/join root "circular_deps" "a.cljs")
         (path/join root "circular_deps" "b.cljs"))


### PR DESCRIPTION
This change was made necessary by the fact that the bootstrap compiler is
asynchronous by default. Therefore, it does not make sense to call
lumo.build.api/build without a callback.

The patch does not break old code, so it still contains the arity without cb,
but includes a warning if that arity is invoked.