### PR TITLE
Ignore the third_party folder, except clojurescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,12 @@ target/
 /build/
 lumo-cache/
 .vagrant
+
+third_party/*
+!third_party/org/
+
+third_party/org/*
+!third_party/org/clojure/
+
+third_party/org/clojure/*
+!third_party/org/clojure/clojurescript/


### PR DESCRIPTION
During development, third_party modifications were leaving the git status dirty. Deleting the folder was not possible because `org/clojure/clojurescript` seems checked out. So a rm + checkout was cleaning up things. We can do better and git supports, with some effort, the un-exclusion of only the clojurescript
dir.