### PR TITLE
Callback call in case of successful compilation and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 The Lumo build API has been enhanced significantly and now includes JS module
 processing, preloads, and is mostly at feature parity with the JVM ClojureScript
 build API.
+One noteworthy feature is the possibility of passing a callback to
+`lumo.build.api/build`: Lumo compilation is intrinsically asynchronous,
+therefore now it is possible to pass a callback.
 
 ### Changes
 

--- a/packages/lumo/README.md
+++ b/packages/lumo/README.md
@@ -75,6 +75,43 @@ Enter `lumo` at the command line to launch it.
 
 Check out `lumo -h` for usage instructions and supported command line options.
 
+### Compile ClojureScript
+
+Lumo can compile ClojureScript code as of version `1.2.0`. See the introductory
+[blog post](https://anmonteiro.com/2017/02/compiling-clojurescript-projects-without-the-jvm/).
+It is still considered experimental, given the relatively new Google Closure
+Compiler [port](https://github.com/google/closure-compiler-js) to JavaScript,
+but it aims to be at feature parity with the JVM ClojureScript compiler.
+
+The build API mirrors the ClojureScript one. Please reference its
+[Quick Start](https://clojurescript.org/guides/quick-start) and the
+[Compiler Options](https://clojurescript.org/reference/compiler-options).  You
+can basically just replace the namespace with `lumo.build.api`:
+
+```clojure
+(require 'lumo.build.api)
+
+(lumo.build.api/build "src" {:output-to "out/main.js"})
+```
+
+The Lumo compiler is completely asynchronous whereas the ClojureScript compiler
+is sync. This means that you can pass a callback in:
+
+```clojure
+(require '[lumo.build.api :as api])
+
+(api/build
+ (api/inputs "src1" "src2") ;; variadic
+ {:output-to "out/main.js"}
+ (fn [result]
+   (if-let [err (:error result)]
+     (println (.-stack err))
+     (do-something-else result))))
+ ```
+
+The above example also shows how to use multiple source folders. The compiler
+returns a map containing an `:error` key if something went wrong.
+
 ## Building
 
 To build Lumo from source:

--- a/src/cljs/bundled/lumo/closure.cljs
+++ b/src/cljs/bundled/lumo/closure.cljs
@@ -2325,7 +2325,8 @@
                                                                     (util/mkdirs outfile)
                                                                     (spit outfile (slurp (io/resource "cljs/bootstrap_node.js")))))
                                                                 (reset! cljs/*loaded* runtime-loaded)
-                                                                ret)))))))))))))])))))))))))
+                                                                ret)))))))))))))]
+                     (cb nil))))))))))))
 
 (defn target-file-for-cljs-ns
   [ns-sym output-dir]

--- a/src/test/cljs_build/hello/broken_world.cljs
+++ b/src/test/cljs_build/hello/broken_world.cljs
@@ -1,0 +1,4 @@
+(ns hello.broken-world)
+(defn ^:export greet
+  ;; [n]
+  (str "Hello " n))

--- a/src/test/cljs_build/hello/world.cljs
+++ b/src/test/cljs_build/hello/world.cljs
@@ -1,0 +1,3 @@
+(ns hello.world)
+(defn ^:export greet [n]
+  (str "Hello " n))

--- a/src/test/lumo/lumo/build_api_tests.cljs
+++ b/src/test/lumo/lumo/build_api_tests.cljs
@@ -341,6 +341,34 @@
       (is (empty? @ws))))
   (test/delete-node-modules))
 
+(deftest cljs-test-compilation
+
+  (testing "success"
+    (let [out (path/join (test/tmp-dir) "compilation-test-out")
+          root "src/test/cljs_build"]
+      (test/delete-out-files out)
+      (build/build
+       (path/join root "hello" "world.cljs")
+       {:main 'hello
+        :optimizations :none
+        :output-to out}
+       (env/default-compiler-env)
+       (fn [ret]
+         (is (nil? ret) "Successful compilation should call the callback with nil")))))
+
+  (testing "failure"
+    (let [out (path/join (test/tmp-dir) "compilation-test-out")
+          root "src/test/cljs_build"]
+      (test/delete-out-files out)
+      (build/build
+       (path/join root "hello" "broken_world.cljs")
+       {:main 'hello
+        :optimizations :none
+        :output-to out}
+       (env/default-compiler-env)
+       (fn [{:keys [error]}]
+         (is (some? error) "Failed compilation should call the callback with some error"))))))
+
 ;; (deftest test-emit-global-requires-cljs-2214
 ;;   (testing "simplest case, require"
 ;;     (let [ws (atom [])


### PR DESCRIPTION
This patch does the actual call to the input compilation callback in case of
success. The returned value is the `:url` of the compiled JavaScript, which
usually is the relative path to it.

Plus minimal documentation.