### PR TITLE
Bump node to 8.6.0 and fixes #283 and #286

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 - lumo.compiler/cljs-files-in can match dirs ([#270](https://github.com/anmonteiro/lumo/issues/270)).
 - Fix bug in the build API caused by requiring `cljs.spec.test.alpha` ([#273](https://github.com/anmonteiro/lumo/issues/273)).
 - Fix compilation crash with macros & `:optimize-constants true` ([#274](https://github.com/anmonteiro/lumo/issues/274)).
+- Require fails if Lumo output is redirected ([#283](https://github.com/anmonteiro/lumo/issues/283)).
+- Lumo script failure when redirecting stdout? ([#286](https://github.com/anmonteiro/lumo/issues/286)).
+
+### Changes
+
+- Upgrade Node.js to version 8.6.0.
 
 ## [1.8.0-beta](https://github.com/anmonteiro/lumo/compare/1.7.0...1.8.0-beta) (2017-09-16)
 

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -6,7 +6,7 @@ const os = require('os');
 const zlib = require('zlib');
 const embed = require('./embed');
 
-const nodeVersion = '8.5.0';
+const nodeVersion = '8.6.0';
 
 function getDirContents(dir, accumPath = dir) {
   let filenames = fs.readdirSync(dir);


### PR DESCRIPTION
The is a strange bug in node 8.5.0 that prevents redirection to work
properly. The bug has solved itself in the new 8.6.0 and therefore lumo can now
follow suit and bump as well.