### PR TITLE
Handle scoped packages when loading Cljs from node dirs

### DIFF
--- a/src/js/lumo.js
+++ b/src/js/lumo.js
@@ -64,13 +64,23 @@ function scanModules(
     return libPath ? libPaths.concat(libPath) : libPaths;
   }
 
-  const modulePath = path.resolve(baseDir, moduleName);
-  return fs
-    .readdirSync(modulePath)
-    .reduce((acc: string[], childName: string) => {
-      const parentPath = path.join(baseDir, moduleName);
-      return acc.concat(scanModules(acc, parentPath, childName));
-    }, libPaths);
+  let newLibPaths = libPaths;
+
+  if (moduleName.startsWith('@')) {
+    try {
+      const modulePath = path.resolve(baseDir, moduleName);
+
+      if (fs.lstatSync(modulePath).isDirectory()) {
+        newLibPaths = fs
+          .readdirSync(modulePath)
+          .reduce((acc: string[], childName: string) => {
+            const parentPath = path.join(baseDir, moduleName);
+            return acc.concat(scanModules(acc, parentPath, childName));
+          }, libPaths);
+      }
+    } catch (_) {} // eslint-disable-line no-empty
+  }
+  return newLibPaths;
 }
 
 function modulesByNodeDir(): Map<string, string[]> {

--- a/src/js/lumo.js
+++ b/src/js/lumo.js
@@ -10,36 +10,96 @@ import JSZip from 'jszip';
 import ArrayStream from './array-stream';
 import * as util from './util';
 
-function inferNodeModulesClasspathLibs(): string[] {
-  const result = [];
+type PackageJsonType = {
+  directories: {
+    lib: string,
+    cache: string,
+  },
+};
+
+function packageJson(
+  nodeDir: string,
+  moduleName: string,
+): ?PackageJsonType {
+  let pkgJson = null;
+
+  try {
+    pkgJson = JSON.parse(
+      fs.readFileSync(path.join(nodeDir, moduleName, 'package.json'), 'utf8'),
+    );
+  } catch (_) {} // eslint-disable-line no-empty
+
+  return pkgJson;
+}
+
+function inferClasspathLib(
+  nodeDir: string,
+  moduleName: string,
+  pkgJson: PackageJsonType,
+): ?string {
+  let libPath = null;
+
+  try {
+    if (pkgJson.directories != null) {
+      libPath = pkgJson.directories.lib;
+
+      if (libPath != null) {
+        libPath = path.resolve(nodeDir, moduleName, libPath);
+      }
+    }
+  } catch (_) {} // eslint-disable-line no-empty
+
+  return libPath;
+}
+
+function scanModules(
+  libPaths: string[],
+  baseDir: string,
+  moduleName: string,
+): string[] {
+  const pkgJson = packageJson(baseDir, moduleName);
+
+  if (pkgJson) {
+    const libPath = inferClasspathLib(baseDir, moduleName, pkgJson);
+    return libPath ? libPaths.concat(libPath) : libPaths;
+  }
+
+  const modulePath = path.resolve(baseDir, moduleName);
+  return fs
+    .readdirSync(modulePath)
+    .reduce((acc: string[], childName: string) => {
+      const parentPath = path.join(baseDir, moduleName);
+      return acc.concat(scanModules(acc, parentPath, childName));
+    }, libPaths);
+}
+
+function modulesByNodeDir(): Map<string, string[]> {
+  const moduleByDir: Map<string, string[]> = new Map();
 
   // $FlowIssue: it's there
-  for (const nodeDir of Module._nodeModulePaths(process.cwd())) {
+  Module._nodeModulePaths(process.cwd()).forEach((nodeDir: string) => {
     try {
-      const modules = fs.readdirSync(nodeDir);
-
-      for (const moduleName of modules) {
-        try {
-          const pkgJson = JSON.parse(
-            fs.readFileSync(
-              path.join(nodeDir, moduleName, 'package.json'),
-              'utf8',
-            ),
-          );
-
-          if (pkgJson.directories != null) {
-            const libPath = pkgJson.directories.lib;
-
-            if (libPath != null) {
-              result.push(path.resolve(nodeDir, moduleName, libPath));
-            }
-          }
-        } catch (_) {} // eslint-disable-line no-empty
-      }
+      moduleByDir.set(nodeDir, fs.readdirSync(nodeDir));
     } catch (_) {} // eslint-disable-line no-empty
+  });
+
+  return moduleByDir;
+}
+
+/* eslint-disable no-loop-func */
+function inferNodeModulesClasspathLibs(): string[] {
+  let result = [];
+
+  for (const [nodeDir, modules] of modulesByNodeDir()) {
+    modules
+      .filter((moduleName: string) => !moduleName.startsWith('.'))
+      .forEach((moduleName: string) => {
+        result = result.concat(scanModules([], nodeDir, moduleName));
+      });
   }
   return result;
 }
+/* eslint-enable no-loop-func */
 
 const sourcePaths = {
   manual: new Set([process.cwd()]),


### PR DESCRIPTION
The inferNodeModulesClasspathLibs function becomes recursive so that we can
skip directories that don't contain package.json (like scoped package ones).

My Javascript is super poor and it took actually quite a bit to implement this one,
All the changes in the review on styling will be accepted with no barf :smile: