### PR TITLE
Add watch: lumo.closure/watch and lumo.build.api/watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove #_=> from pasted code ([#261](https://github.com/anmonteiro/lumo/issues/261)).
 - Allow CLJS require from `node_modules` ([#130](https://github.com/anmonteiro/lumo/issues/130)).
 - Make `dir` work on aliases.
+- Added `lumo.build.api/watch` ([#321](https://github.com/anmonteiro/lumo/issues/321)).
 
 ### Bug fixes
 

--- a/src/cljs/bundled/lumo/build/api.cljs
+++ b/src/cljs/bundled/lumo/build/api.cljs
@@ -183,6 +183,20 @@
    (binding [ana/*cljs-warning-handlers* (:warning-handlers opts ana/*cljs-warning-handlers*)]
      (closure/build source opts compiler-env))))
 
+(defn watch
+  "Given a source which can be compiled, watch it for changes to produce."
+  ([source opts]
+   (watch source opts
+     (if-not (nil? env/*compiler*)
+       env/*compiler*
+       (env/default-compiler-env
+         (closure/add-externs-sources opts)))))
+  ([source opts compiler-env]
+   (watch source opts compiler-env nil))
+  ([source opts compiler-env stop]
+   (binding [ana/*cljs-warning-handlers* (:warning-handlers opts ana/*cljs-warning-handlers*)]
+     (closure/watch source opts compiler-env stop))))
+
 ;; =============================================================================
 ;; Node.js / NPM dependencies
 

--- a/src/cljs/bundled/lumo/closure.cljs
+++ b/src/cljs/bundled/lumo/closure.cljs
@@ -2268,7 +2268,8 @@
                   (catch js/Error e
                     (if-let [f (:watch-error-fn opts)]
                       (f e)
-                      (println e)))))
+                      (binding [*print-fn* *print-err-fn*]
+                        (println e))))))
               (watch-all [root]
                 (.watch fs root #js {:recursive true}
                         (fn [change fstr]

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -127,6 +127,7 @@ function newDevelopmentContext(): vm$Context {
     require,
     process,
     console,
+    setTimeout,
     $$LUMO_GLOBALS: {
       crypto,
       fs,


### PR DESCRIPTION
This works and recompiles my changes fast,
example
```
(require 'lumo.build.api)

(lumo.build.api/watch
         "samples/hello"
         {:optimizations :none
         :output-to "samples/out/hello.js"
         :output-dir "samples/out"
         :cache-analysis true
         :source-map true
         :verbose true
         :watch-fn
         (fn []
             (println "Success!"))})
```

Few point:
if the directory to watch is not found when passed to `lumo.closure/build` it will not warn that the directory doesn't exist but fail like this
```
 Object.fs.openSync (fs.cljs:663:18)
	 fs.readFileSync (fs.cljs:568:33)
	 lumo$io$slurp (evalmachine.<anonymous>:11:44)
	 Function.lumo.analyzer.forms_seq_STAR_.cljs$core$IFn$_invoke$arity$2 (evalmachine.<anonymous>:105:90)
	 lumo$analyzer$forms_seq_STAR_ (evalmachine.<anonymous>:83:38)
	 (evalmachine.<anonymous>:263:66)
	 Function.lumo.analyzer.parse_ns.cljs$core$IFn$_invoke$arity$3 (evalmachine.<anonymous>:355:4)
	 lumo$analyzer$parse_ns (evalmachine.<anonymous>:201:31)
	 Function.lumo.analyzer.parse_ns.cljs$core$IFn$_invoke$arity$1 (evalmachine.<anonymous>:211:31)
	 lumo$analyzer$parse_ns (evalmachine.<anonymous>:193:31)
```
we can open a ticket for that

This watcher is not collecting saved files in queues, and I'm not even sure we need to mark nses for recompilation, for example the require function will not work due to spec failing on it being not quoted and in top position. Despite that I left these functions there and seemingly don't do any harm (or perhaps are the reason this all works).

https://github.com/anmonteiro/lumo/issues/321