### PR TITLE
on empty line-suffix, don't get completions

### DIFF
--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -1445,12 +1445,14 @@
           ns-alias (second (re-find #"\(*(\b[a-zA-Z-.<>*=&?]+)/[a-zA-Z-]*$" line))
           line-match-suffix (first (re-find #":?([a-zA-Z-.<>*=&?]*|^\(/)$" line))
           line-prefix (subs line 0 (- (count line) (count line-match-suffix)))
-          completions (reduce (fn [ret item]
-                                (doto ret
-                                  (.push (str line-prefix item))))
+          completions (if (empty? line-match-suffix)
                         #js []
-                        (filter #(is-completion? line-match-suffix %)
-                          (completion-candidates top-level? ns-alias)))]
+                       (reduce (fn [ret item]
+                                  (doto ret
+                                    (.push (str line-prefix item))))
+                                #js []
+                                (filter #(is-completion? line-match-suffix %)
+                                        (completion-candidates top-level? ns-alias))))]
       (cb (doto completions
             .sort)))))
 


### PR DESCRIPTION
This is an old pain, but this is not a final solution as symbol names ending with alphanumeric number are legal symbols in Clojure as far as I can tell. Next step should be to modify `(re-find #":?([a-zA-Z-.<>*=&?]*|^\(/)$" line)` to something better (including number, or match all except xy). In any case tough, if this re-find doesn't find anything, (ie. invalid?) then completions should not continue, as empty string causes something like this

```
(time (do (lumo.repl/get-completions "red6" #(prn %)) nil))
d6qualified-ident?" "red6qualified-keyword?" "red6qualified-symbol?" "red6quot" "red6rand" "red6rand-int" "red6rand-nth" "red6random-sample" "red6random-uuid" "red6range" "red6ranged-iterator" "red6re-find" "red6re-matches" "red6re-pattern" "red6re-seq" "red6realized?" "red6record?" "red6reduce" "red6reduce-kv" "red6reduceable?" "red6reduced" "red6reduced?" "red6reductions" "red6refer-clojure" "red6regexp?" "red6reify" "red6rem" "red6remove" "red6remove-all-methods" "red6remove-method" "red6remove-watch" "red6repeat" "red6repeatedly" "red6replace" "red6replicate" "red6require" "red6require-macros" "red6reset!" "red6reset-meta!" "red6reset-vals!" "red6resolve" "red6rest" "red6reverse" "red6reversible?" "red6rseq" "red6rsubseq" "red6run!" "red6satisfies?" "red6second" "red6select-keys" "red6seq" "red6seq-iter" "red6seq?" "red6seqable?" "red6sequence" "red6sequential?" "red6set" "red6set-from-indexed-seq" "red6set-print-err-fn!" "red6set-print-fn!" "red6set-validator!" "red6set?" "red6short" "red6shorts" "red6shuffle" "red6simple-benchmark" "red6simple-ident?" "red6simple-keyword?" "red6simple-symbol?" "red6some" "red6some->" "red6some->>" "red6some-fn" "red6some?" "red6someprotopackage.TestPackageTypes" "red6sort" "red6sort-by" "red6sorted-map" "red6sorted-map-by" "red6sorted-set" "red6sorted-set-by" "red6sorted?" "red6source" "red6special-symbol?" "red6specify" "red6specify!" "red6split-at" "red6split-with" "red6spread" "red6str" "red6string-hash-cache" 
..elided...
"Elapsed time: 553.308537 msecs"
```