### PR TITLE
Suspension

### DIFF
--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -667,9 +667,7 @@
   (let [front #js []
         back #js []
         cb (volatile! nil)
-        spill! #(loop []
-                  (when-some [s (.pop back)]
-                    (do (.push front s) (recur))))]
+        spill! #(when-some [s (.pop back)] (.push front s) (recur))]
     #js [(fn 
            ([]
              (spill!)

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -1055,7 +1055,9 @@
    :*2 *2
    :*3 *3
    :*e *e
-   :ns @current-ns})
+   :ns @current-ns
+   :*print-fn* *print-fn*
+   :*print-err-fn* *print-err-fn*})
 
 (defn- set-session-state!
   "Sets the session state given a sesssion state map."
@@ -1070,7 +1072,9 @@
   (set! *2 (:*2 session-state))
   (set! *3 (:*3 session-state))
   (set! *e (:*e session-state))
-  (vreset! current-ns (:ns session-state)))
+  (vreset! current-ns (:ns session-state))
+  (set! *print-fn* (:*print-fn* session-state))
+  (set! *print-err-fn* (:*print-err-fn* session-state)))
 
 (def ^{:private true
        :doc "The default state used to initialize a new REPL session."}
@@ -1090,7 +1094,10 @@
 (defn- set-session-state-for-session-id!
   "Sets the session state for a given session."
   [session-id]
-  (set-session-state! (get @session-states session-id @default-session-state)))
+  (set-session-state! (or (get @session-states session-id)
+                        (assoc @default-session-state
+                          :*print-fn* *print-fn*
+                          :*print-err-fn* *print-err-fn*))))
 
 (defn- capture-session-state-for-session-id
   "Captures the session state for a given session."

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -668,15 +668,15 @@
         back #js []
         cb (volatile! nil)
         spill! #(when-some [s (.pop back)] (.push front s) (recur))]
-    #js [(fn 
-           ([]
+    #js [(fn line-cb
+           ([] ; 0-arg is called on resumption by repl.js to retrieve the content of the buffer
              (spill!)
              (when-some [last (.pop front)]
-               ; remove last newline when going back to repl/readline
+               ; remove last newline since repl/readline assumes no trailing newline
                (let [n (dec (.-length last))]
                  (.push front (if (= \newline (.charAt last n)) (subs last 0 n) last))))
              (.join front ""))
-           ([s]
+           ([s] ; 1-arg is called by repl.js when new input is available 
              (when (and s (not= "" s)) ; TODO handle EOF
                (let [s (str s "\n")]
                  (if-some [f @cb]

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -270,6 +270,7 @@ export function execute(
   printNilResult?: boolean = true,
   sessionID?: number = 0,
   setNS?: string,
+  yieldControl: () => void,
 ): void {
   // $FlowIssue: context can have globals
   return ClojureScriptContext.lumo.repl.execute(
@@ -279,6 +280,7 @@ export function execute(
     printNilResult,
     setNS,
     sessionID,
+    yieldControl
   );
 }
 
@@ -313,6 +315,10 @@ export function isPrintingNewline(): boolean {
 export function clearREPLSessionState(sessionID: number): void {
   // $FlowIssue: context can have globals
   return ClojureScriptContext.lumo.repl.clear_state_for_session(sessionID);
+}
+
+export function createAsyncPipe() {
+	return ClojureScriptContext.lumo.repl.create_async_pipe();
 }
 
 function executeScript(

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -207,13 +207,13 @@ function setRuntimeOpts(opts: CLIOptsType): void {
   );
 }
 
-function mkPrintFn(cljsSender: stream$Writable) {
-	return (...args: string[]): void => {
-		if (utilBinding.watchdogHasPendingSigint()) {
-			throw interruptSentinel;
-		}
-		cljsSender.write(args.join(' '));
-	};
+function mkPrintFn(cljsSender: stream$Writable): () => void {
+    return (...args: string[]): void => {
+        if (utilBinding.watchdogHasPendingSigint()) {
+            throw interruptSentinel;
+        }
+        cljsSender.write(args.join(' '));
+    };
 }
 
 const printErrFn = mkPrintFn(process.stderr);
@@ -224,9 +224,9 @@ export function setPrintFns(stream?: stream$Writable): void {
     ClojureScriptContext.cljs.core.set_print_fn_BANG_(printOutFn);
     ClojureScriptContext.cljs.core.set_print_err_fn_BANG_(printErrFn);
   } else {
-	const printFn = mkPrintFn(stream)
-	ClojureScriptContext.cljs.core.set_print_fn_BANG_(printFn);
-	ClojureScriptContext.cljs.core.set_print_err_fn_BANG_(printFn);
+    const printFn = mkPrintFn(stream);
+    ClojureScriptContext.cljs.core.set_print_fn_BANG_(printFn);
+    ClojureScriptContext.cljs.core.set_print_err_fn_BANG_(printFn);
   }
 }
 
@@ -272,7 +272,7 @@ export function execute(
     printNilResult,
     setNS,
     sessionID,
-    yieldControl
+    yieldControl,
   );
 }
 
@@ -309,8 +309,8 @@ export function clearREPLSessionState(sessionID: number): void {
   return ClojureScriptContext.lumo.repl.clear_state_for_session(sessionID);
 }
 
-export function createAsyncPipe() {
-	return ClojureScriptContext.lumo.repl.create_async_pipe();
+export function createAsyncPipe(): array {
+    return ClojureScriptContext.lumo.repl.create_async_pipe();
 }
 
 function executeScript(

--- a/src/js/cljs.js
+++ b/src/js/cljs.js
@@ -221,11 +221,15 @@ const printOutFn = mkPrintFn(process.stdout);
 
 export function setPrintFns(stream?: stream$Writable): void {
   if (stream == null || stream === process.stdout) {
+    // $FlowIssue: context can have globals
     ClojureScriptContext.cljs.core.set_print_fn_BANG_(printOutFn);
+    // $FlowIssue: context can have globals
     ClojureScriptContext.cljs.core.set_print_err_fn_BANG_(printErrFn);
   } else {
     const printFn = mkPrintFn(stream);
+    // $FlowIssue: context can have globals
     ClojureScriptContext.cljs.core.set_print_fn_BANG_(printFn);
+    // $FlowIssue: context can have globals
     ClojureScriptContext.cljs.core.set_print_err_fn_BANG_(printFn);
   }
 }
@@ -255,6 +259,8 @@ function initClojureScriptEngine(opts: CLIOptsType): void {
   setRuntimeOpts(opts);
 }
 
+export type AsyncReader = {};
+
 export function execute(
   code: string,
   type?: string = 'text',
@@ -262,7 +268,7 @@ export function execute(
   printNilResult?: boolean = true,
   sessionID?: number = 0,
   setNS?: string,
-  yieldControl: () => void,
+  yieldControl?: (f: (async_reader: AsyncReader, resume_cb: ()=>void) => void) => void,
 ): void {
   // $FlowIssue: context can have globals
   return ClojureScriptContext.lumo.repl.execute(
@@ -309,8 +315,9 @@ export function clearREPLSessionState(sessionID: number): void {
   return ClojureScriptContext.lumo.repl.clear_state_for_session(sessionID);
 }
 
-export function createAsyncPipe(): array {
-    return ClojureScriptContext.lumo.repl.create_async_pipe();
+export function createAsyncPipe(): [(s?: string)=>string, AsyncReader] {
+  // $FlowIssue: context can have globals
+  return ClojureScriptContext.lumo.repl.create_async_pipe();
 }
 
 function executeScript(

--- a/src/js/repl.js
+++ b/src/js/repl.js
@@ -11,6 +11,7 @@ import { currentTimeMicros, isWhitespace, indentationSpaces } from './util';
 import { close as socketServerClose } from './socketRepl';
 
 import type { CLIOptsType } from './cli';
+import type { AsyncReader } from './cljs';
 
 type KeyType = {
   name: string,
@@ -23,7 +24,7 @@ type KeyType = {
 export type REPLSession = {
   id: number,
   rl: readline$Interface,
-  linecb?: (s?: string) => void,
+  linecb: ?(s?: string) => string,
   isMain: boolean,
   isReverseSearch: boolean,
   reverseSearchBuffer: string,
@@ -93,7 +94,7 @@ export function processLine(replSession: REPLSession, line: string): void {
   }
 
   let suspended;
-  function yieldControl(f: (async_reader: object, resume_cb: ()=>void)=>void): void {
+  function yieldControl(f: (async_reader: AsyncReader, resume_cb: ()=>void)=>void): void {
       suspended = true;
       const [linecb, reader] = cljs.createAsyncPipe();
       session.linecb = linecb;
@@ -141,6 +142,7 @@ export function processLine(replSession: REPLSession, line: string): void {
       if (suspended) {
           // yieldControl has been called, user code is in control
           session.input = '';
+          // $FlowIssue: linecb is guaranteed to be defined when suspended
           session.linecb(extraForms);
           break;
       }

--- a/src/js/repl.js
+++ b/src/js/repl.js
@@ -23,7 +23,7 @@ type KeyType = {
 export type REPLSession = {
   id: number,
   rl: readline$Interface,
-  linecb?: (s?:string) => void,
+  linecb?: (s?: string) => void,
   isMain: boolean,
   isReverseSearch: boolean,
   reverseSearchBuffer: string,
@@ -86,25 +86,25 @@ function inferPastingBehavior(replSession: REPLSession): void {
 export function processLine(replSession: REPLSession, line: string): void {
   const session = replSession;
   const { input, rl, isMain } = session;
-  
+
   if (session.linecb) {
-	  session.linecb(line);
-	  return;
+      session.linecb(line);
+      return undefined;
   }
 
-  let extraForms, suspended;
-  function yieldControl(f) {
-	  suspended = true;
-	  const [linecb, reader] = cljs.createAsyncPipe();
-	  session.linecb = linecb;
-	  const prompt = rl._prompt;
-	  rl.setPrompt('');
-	  f(reader, () => {
-		  session.linecb = null;
-		  rl.setPrompt(prompt);
-		  processLine(session, linecb());
-	  });
-  };
+  let suspended;
+  function yieldControl(f: (async_reader: object, resume_cb: ()=>void)=>void): void {
+      suspended = true;
+      const [linecb, reader] = cljs.createAsyncPipe();
+      session.linecb = linecb;
+      const bakprompt = rl._prompt;
+      rl.setPrompt('');
+      f(reader, () => {
+          session.linecb = null;
+          rl.setPrompt(bakprompt);
+          processLine(session, linecb());
+      });
+  }
 
   if (exitCommands.has(line.trim())) {
     // $FlowIssue - use of rl.output
@@ -117,6 +117,7 @@ export function processLine(replSession: REPLSession, line: string): void {
     session.input = `${input}\n${line}`;
   }
 
+  let extraForms;
   for (;;) {
     const currentInput = session.input;
     extraForms = cljs.isReadable(currentInput);
@@ -138,12 +139,12 @@ export function processLine(replSession: REPLSession, line: string): void {
       suspended = false;
       cljs.execute(session.input, 'text', true, true, session.id, undefined, yieldControl);
       if (suspended) {
-    	  // yieldControl has been called, user code is in control
-    	  session.input = '';
-    	  session.linecb(extraForms);
-    	  break;
+          // yieldControl has been called, user code is in control
+          session.input = '';
+          session.linecb(extraForms);
+          break;
       }
-      
+
       currentREPLInterface = null;
       cljs.setPrintFns();
       // If *print-newline* is off, we need to emit a newline now, otherwise
@@ -291,7 +292,7 @@ function handleKeyPress(
   const isReverseSearchKey = ctrl && name === 'r';
 
   if (session.linecb) return;
-  
+
   // TODO: factor this out into own function
   if (isReverseSearch || isReverseSearchKey) {
     let failedSearch = false;

--- a/src/js/repl.js
+++ b/src/js/repl.js
@@ -92,13 +92,16 @@ export function processLine(replSession: REPLSession, line: string): void {
 	  return;
   }
 
-  let extraForms, suspended; // suspended is either a boolean or a function
+  let extraForms, suspended;
   function yieldControl(f) {
 	  suspended = true;
 	  const [linecb, reader] = cljs.createAsyncPipe();
 	  session.linecb = linecb;
+	  const prompt = rl._prompt;
+	  rl.setPrompt('');
 	  f(reader, () => {
 		  session.linecb = null;
+		  rl.setPrompt(prompt);
 		  processLine(session, linecb());
 	  });
   };
@@ -287,6 +290,8 @@ function handleKeyPress(
   const { rl, isReverseSearch } = session;
   const isReverseSearchKey = ctrl && name === 'r';
 
+  if (session.linecb) return;
+  
   // TODO: factor this out into own function
   if (isReverseSearch || isReverseSearchKey) {
     let failedSearch = false;


### PR DESCRIPTION
This is a solution to #294.

User code wanting to take control of the repl must evaluate to a _suspension request_ (created with `lumo.repl/suspension-request`).

When the repl sees a suspension request being returned, instead of printing it and "looping", it suspends itself and yield control to the callback embedded in the suspension request.

Two arguments are passed to this callback: an object satisfying `lumo.repl/AsyncReader` (the input stream) and a `resume` callback to call when user code reaches completion to resume the repl. This callback take a map with keys `:value`, `:error` and `:ns`. The repl resumes at the "print" phase.

The `AsyncReader` protocol has been introduced as a platform agnostic interface over streams -- even if it's currently namespaced in lumo.