### PR TITLE
Improve robustness of completions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Don't look for the REPL history file in the user's home directory if one doesn't exist ([#309](https://github.com/anmonteiro/lumo/issues/309)).
 - Use `tools.reader` with the unicode literal / cljs.core/bit-or warning ([#341](https://github.com/anmonteiro/lumo/issues/341)).
 - Auto-completion fails with numbers in ns names ([#332](https://github.com/anmonteiro/lumo/issues/332))
+- Add common metadata keys to completion keywords ([#344](https://github.com/anmonteiro/lumo/issues/344)).
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Load required macro namespaces when reading analysis cache ([#308](https://github.com/anmonteiro/lumo/issues/308)).
 - Don't look for the REPL history file in the user's home directory if one doesn't exist ([#309](https://github.com/anmonteiro/lumo/issues/309)).
 - Use `tools.reader` with the unicode literal / cljs.core/bit-or warning ([#341](https://github.com/anmonteiro/lumo/issues/341)).
+- Auto-completion fails with numbers in ns names ([#332](https://github.com/anmonteiro/lumo/issues/332))
 
 ### Changes
 

--- a/circle.yml
+++ b/circle.yml
@@ -23,22 +23,19 @@ dependencies:
     - "tmp"
     - "~/.boot/cache/lib"
     - "~/.boot/cache/bin"
-    - "/usr/local/bin/yarn"
-    - "/usr/local/bin/yarnpkg"
-    - "/usr/local/bin/wget"
+    - "~/.yarn"
+    - "~/.config/yarn"
     - "/usr/local/bin/boot"
     - "/usr/local/lib/node_modules"
     - "/usr/local/Cellar"
   pre:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash && export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
     - nvm install v9.2.0
-    - if [[ ! -e /usr/local/bin/yarn ]]; then brew install yarn; fi
-    - if [[ ! -e /usr/local/bin/wget ]]; then brew install wget; fi
+    - if [[ ! -d "$HOME/.yarn" ]]; then curl -o- -L https://yarnpkg.com/install.sh | bash; fi
     - |
       if [[ ! -e /usr/local/bin/boot ]];
       then
-        wget https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh
-        mv boot.sh boot && chmod a+x boot && sudo mv boot /usr/local/bin;
+        cd /usr/local/bin && curl -fsSLo boot https://github.com/boot-clj/boot-bin/releases/download/latest/boot.sh && chmod 755 boot
       fi
     - if [[ ! -e tmp/node ]]; then boot release-ci; fi
   override:

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -1445,12 +1445,14 @@
           ns-alias (second (re-find #"\(*(\b[a-zA-Z-.<>*=&?]+)/[a-zA-Z-]*$" line))
           line-match-suffix (first (re-find #":?([a-zA-Z-.<>*=&?]*|^\(/)$" line))
           line-prefix (subs line 0 (- (count line) (count line-match-suffix)))
-          completions (reduce (fn [ret item]
-                                (doto ret
-                                  (.push (str line-prefix item))))
+          completions (if (empty? line-match-suffix)
                         #js []
-                        (filter #(is-completion? line-match-suffix %)
-                          (completion-candidates top-level? ns-alias)))]
+                       (reduce (fn [ret item]
+                                  (doto ret
+                                    (.push (str line-prefix item))))
+                                #js []
+                                (filter #(is-completion? line-match-suffix %)
+                                        (completion-candidates top-level? ns-alias))))]
       (cb (doto completions
             .sort)))))
 

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -1336,10 +1336,13 @@
      :clj :cljs
      :default
      :else
+     :private :doc :author
      :gen-class
      :keywordize-keys
      :req :req-un :opt :opt-un
-     :args :ret :fn]))
+     :args :ret :fn
+     :const
+     :arglists :tag :static :added]))
 
 (def ^:private namespace-completion-exclusions
   (into #{} (map str)

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -1444,7 +1444,7 @@
     (let [top-level? (boolean (re-find #"^\s*\(\s*[^()\s]*$" line))
           skip-suffix-check? (or (= "(" line) (string/ends-with? line "/") (empty? line))
           ns-alias (second (re-find #"\(*(\b[a-zA-Z-.<>*=&?]+)/[a-zA-Z-]*$" line))
-          line-match-suffix (first (re-find #":?([a-zA-Z-.<>*=&?]*|^\(/)$" line))
+          line-match-suffix (first (re-find #"^:$|:?([a-zA-Z-.<>_*=&?]{1}[a-zA-Z0-9-.'<>_*=&?]*|^\(/)$" line))
           line-prefix (subs line 0 (- (count line) (count line-match-suffix)))
           completions (reduce (fn [ret item]
                                 (doto ret

--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -1444,7 +1444,7 @@
        :doc "The symbol detection regex.
 
 This was taken from the reader specification plus tests at the Clojure REPL."}
-  completion-symbol-regex "[a-zA-Z-.<>_*=&?$%!]{1}[a-zA-Z0-9-.<>_*=&?%$!']")
+  completion-symbol-regex "[a-zA-Z-.<>_*=&?$%!]{1}[a-zA-Z0-9-.<>_*=&?%$!']*")
 
 (defn ^:export get-completions
   [line cb]
@@ -1452,7 +1452,7 @@ This was taken from the reader specification plus tests at the Clojure REPL."}
     (js/$$LUMO_GLOBALS.getJSCompletions line (second js-matches) cb)
     (let [top-level? (boolean (re-find #"^\s*\(\s*[^()\s]*$" line))
           skip-suffix-check? (or (= "(" line) (string/ends-with? line "/") (empty? line))
-          ns-alias (second (re-find (js/RegExp. (str "\\(*(\\b" completion-symbol-regex "+)/"  ;; either ending in /
+          ns-alias (second (re-find (js/RegExp. (str "\\(*(\\b" completion-symbol-regex ")/"   ;; either ending in /
                                                      "|/" completion-symbol-regex "$")) line)) ;; or in /symbol
           line-match-suffix (first (re-find (js/RegExp. (str "^:$|:?(" completion-symbol-regex "|^\\(/)$")) line))
           line-prefix (subs line 0 (- (count line) (count line-match-suffix)))

--- a/src/test/lumo/lumo/repl_tests.cljs
+++ b/src/test/lumo/lumo/repl_tests.cljs
@@ -132,8 +132,20 @@
     (testing "prefix filtering"
       (with-redefs [lumo/get-namespace (fn []
                                          '{:defs {red6hlolli {:name cljs.user/red6hlolli}}})]
-        (is-contains-completion "red6" "red6hlolli")))))
-
+        (is-contains-completion "red6" "red6hlolli")))
+    (testing "LUMO-332"
+      (with-redefs [lumo/get-namespace (fn [ns]
+                                         '{:name foo-1.core
+                                           :defs {xyz {:name foo-1.core/xyz}
+                                                  bar2 {:name foo-1.core/bar2}
+                                                  baz-3 {:name foo-1.core/baz-3}}
+                                           :uses {foo-1 foo-1.core}
+                                           :requires {foo-1.core foo-1.core}})
+                    lumo/all-ns (fn []
+                                  '(foo-1.core))]
+        (is-completion "foo-1.co" ["foo-1.core"])
+        (is-completion "foo-1.core/" ["foo-1.core/baz-3" "foo-1.core/bar2" "foo-1.core/xyz"])
+        (is-completion "foo-1.core/ba" ["foo-1.core/baz-3" "foo-1.core/bar2"])))))
 
 
 (deftest test-root-resource

--- a/src/test/lumo/lumo/repl_tests.cljs
+++ b/src/test/lumo/lumo/repl_tests.cljs
@@ -65,7 +65,7 @@
       (is-completion "" (lumo/completion-candidates false nil)))
     (testing "keyword completions"
       (is-completion ":" lumo/keyword-completions)
-      (is-completion ":a" [":args" ":as"])
+      (is-completion ":a" [":added" ":arglists" ":args" ":as" ":author"])
       (is-completion ":ref" [":refer" ":refer-clojure" ":refer-macros"]))
     (testing "aliased namespaces completions"
       (with-redefs [lumo/current-alias-map (fn []


### PR DESCRIPTION
This patch expands on #333 and filters results not only on the suffix but also
on the prefix. This makes sure that we don't return frankstain completions in
case the `line-match-suffix` is empty (effectively not filtering anything).

The problem of the time used to produce the candidates is solved with the use
of `memoize`.