### PR TITLE
Bump Google Closure Compiler Js to 20180204.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "main": "./src/js/index.js",
   "dependencies": {
-    "google-closure-compiler-js": "20170910.0.1",
+    "google-closure-compiler-js": "20180204.0.0",
     "jszip": "2.6.1",
     "paredit.js": "0.3.2",
     "posix-getopt": "github:anmonteiro/node-getopt#master"

--- a/scripts/lumo_test.cljs
+++ b/scripts/lumo_test.cljs
@@ -4,8 +4,20 @@
          ;; needs to be here for testing get-completions
          '[goog :as g])
 
+(def ^:dynamic *print-stack-traces* true)
+
 (defmethod cljs.test/report [:cljs.test/default :end-run-tests] [m]
   (when-not (cljs.test/successful? m)
     (lumo/exit 1)))
+
+(defmethod cljs.test/report [:cljs.test/default :error] [m]
+  (cljs.test/inc-report-counter! :error)
+  (println "\nERROR in" (cljs.test/testing-vars-str m))
+  (when (seq (:testing-contexts (cljs.test/get-current-env)))
+    (println (cljs.test/testing-contexts-str)))
+  (when-let [message (:message m)] (println message))
+  (cljs.test/print-comparison m)
+  (when *print-stack-traces*
+    (println (.-stack (:actual m)))))
 
 (lumo.test-runner/run-all-tests)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,9 +2322,9 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-google-closure-compiler-js@20170910.0.1:
-  version "20170910.0.1"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20170910.0.1.tgz#06c93b215092f4ad57928a8a1b0f129566d2af78"
+google-closure-compiler-js@20180204.0.0:
+  version "20180204.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-js/-/google-closure-compiler-js-20180204.0.0.tgz#05920e0c2e743702a0c293898caf3b49af7a88bb"
   dependencies:
     minimist "^1.2.0"
     vinyl "^2.0.1"


### PR DESCRIPTION
https://github.com/google/closure-compiler-js/releases/tag/20180204.0.0