### PR TITLE
Bump tools.reader to the latest version

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
  :asset-paths #{"src/js" "src/cljs/bundled"}
  :dependencies (into [['org.clojure/clojure       "1.9.0"]
                       ['org.clojure/clojurescript +clojurescript-version+]]
-                     '[[org.clojure/tools.reader    "1.1.2"]
+                     '[[org.clojure/tools.reader    "1.2.2"]
                        [com.cognitect/transit-cljs  "0.8.243"]
                        [malabarba/lazy-map          "1.3"]
                        [fipp                        "0.6.12"]


### PR DESCRIPTION
Same as for ClojureScript: https://github.com/clojure/tools.reader/tree/tools.reader-1.1.3.1