### PR TITLE
Fix Circle CI cached builds when yarn has already been installed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ dependencies:
   pre:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash && export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
     - nvm install v9.2.0
-    - if [[ ! -d "$HOME/.yarn" ]]; then curl -o- -L https://yarnpkg.com/install.sh | bash; fi
+    - if [[ ! -d "$HOME/.yarn" ]]; then curl -o- -L https://yarnpkg.com/install.sh | bash; else export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"; fi
     - |
       if [[ ! -e /usr/local/bin/boot ]];
       then


### PR DESCRIPTION
Installing from the script needs to setup PATH if we cached $HOME/.yarn.