### PR TITLE
Bundle cljs.core.specs.alpha

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -119,6 +119,9 @@
           (-> fileset (add-resource tmp) commit!)))
       (sift :include #{core-caches-re} :invert true))))
 
+(deftask sift-optional-cljs-sources []
+  (sift :add-jar {'org.clojure/clojurescript #"^cljs[\\\/]core[\\\/]specs.*"}))
+
 (deftask sift-cljs-resources []
   (comp
     (sift :add-jar
@@ -198,6 +201,7 @@
 (deftask release-ci []
   (comp
     (install-node-modules)
+    (sift-optional-cljs-sources)
     (compile-cljs)
     (sift-cljs-resources)
     (cache-edn->transit)


### PR DESCRIPTION
Of course this fix cannot go in until the new version of ClojureScript is released containing https://github.com/clojure/clojurescript/commit/9de75f367d31097c78973e31fe4908cc224926fc.

Cause `cljs.core.specs.alpha` is not required anywhere in core, it does not end up in the fileset (`boot-cljs` does not compile what is not depended upon).

This means we need to `sift` it manually.