### PR TITLE
Loop outside binding and fix CLJS master issue

### DIFF
--- a/src/cljs/snapshot/lumo/repl.cljs
+++ b/src/cljs/snapshot/lumo/repl.cljs
@@ -483,28 +483,31 @@
    (print-error error stacktrace? nil))
   ([error stacktrace? printed-message]
    (binding [*print-fn* *print-err-fn*]
-     (print-error-column-indicator error)
-     (let [error (extract-cljs-js-error error)
-           message (ex-message error)]
-       (when (or (not ((fnil string/starts-with? "") printed-message message))
-                 stacktrace?)
-         (println (str message (when (reader-error? error)
-                                 (location-info error)))))
-       #_(when-let [data (and print-ex-data? (ex-data error))]
-         (print-value data {::as-code? false}))
-       (when stacktrace?
-         (let [canonical-stacktrace (st/parse-stacktrace
-                                      {}
-                                      (.-stack error)
-                                      {:ua-product :nodejs}
-                                      {:output-dir "file://(/goog/..)?"})]
-           (println
-             (st/mapped-stacktrace-str
+     (loop [error error
+            stacktrace? stacktrace?
+            printed-message printed-message]
+       (print-error-column-indicator error)
+       (let [error (extract-cljs-js-error error)
+             message (ex-message error)]
+         (when (or (not ((fnil string/starts-with? "") printed-message message))
+                   stacktrace?)
+           (println (str message (when (reader-error? error)
+                                   (location-info error)))))
+         #_(when-let [data (and print-ex-data? (ex-data error))]
+             (print-value data {::as-code? false}))
+         (when stacktrace?
+           (let [canonical-stacktrace (st/parse-stacktrace
+                                       {}
+                                       (.-stack error)
+                                       {:ua-product :nodejs}
+                                       {:output-dir "file://(/goog/..)?"})]
+             (println
+              (st/mapped-stacktrace-str
                canonical-stacktrace
                {}
                nil))))
-       (when-let [cause (.-cause error)]
-         (recur cause stacktrace? message))))))
+         (when-let [cause (.-cause error)]
+           (recur cause stacktrace? message)))))))
 
 (defn- handle-error [error stacktrace?]
   (print-error error stacktrace?)


### PR DESCRIPTION
It looks like the CLJS compiler is now not permitting to recur inside a binding
form. This works around the issue in the only place we do it: print-error.