### PR TITLE
Include node-version in build.boot

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,5 +1,6 @@
 (def +clojurescript-version+ (or (System/getenv "CANARY_CLOJURESCRIPT_VERSION")
                                  "1.9.946"))
+(def +node-version+ "9.2.0")
 
 (set-env!
  :source-paths #{"src/cljs/snapshot"}
@@ -182,7 +183,7 @@
 
 (deftask package-executable []
   (with-pass-thru _
-    (dosh "node" "scripts/package.js")))
+    (dosh "node" "scripts/package.js" +node-version+)))
 
 (deftask backup-resources
   "Backup resources to be gzipped in the 2nd stage binary

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -6,7 +6,7 @@ const os = require('os');
 const zlib = require('zlib');
 const embed = require('./embed');
 
-const nodeVersion = '9.2.0';
+const nodeVersion = process.argv.slice(0)[2];
 
 function getDirContents(dir, accumPath = dir) {
   let filenames = fs.readdirSync(dir);


### PR DESCRIPTION
This small patch gives more visibility to the node version. It is now in
build.boot and it can be easily bumped along with the other deps when the time
comes.