### PR TITLE
Add CONTRIBUTING.md and make it easy to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - yarn test
 - boot test
 - boot release-ci
-- ./build/lumo -c src/test/cljs:src/test/lumo:src/test/cljs_cp -D org.clojure/test.check:0.10.0-alpha2 scripts/lumo_test.cljs --test-cli-option true
+- ./scripts/test-build
 after_success:
 - chmod a+x build/lumo
 - zip -j build/lumo.zip build/lumo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+<img src="./logo/full.png" alt="lumo logo" title="lumo" align="right" width="150" height="150" />
+
+## Submitting a Pull Request (PR)
+
+Before you submit your Pull Request (PR) consider the following guidelines:
+
+* Search [GitHub](https://github.com/anmonteiro/lumo/pulls) for an open or
+  closed PR. You don't want to duplicate effort. Write on the Slack #lumo
+  channel if unsure.
+
+* Create your patch **including appropriate test cases**.
+
+* When finished, run the pre-compilation tests:
+
+  ```shell
+  yarn lint
+  yarn type:check
+  yarn test
+  boot test
+  ```
+
+* Compile `lumo`:
+
+  ```shell
+  boot release
+  ```
+
+* Run the CLJS test suite against `./build/lumo` (Linux or Windows):
+
+  ```shell
+  ./scripts/test-build
+  ```
+
+  ```shell
+  scripts/test-build.bat
+  ```
+
+* Add your PR changes to the
+  [CHANGELOG.md](https://raw.githubusercontent.com/anmonteiro/lumo/master/CHANGELOG.md),
+  including the relevant link to either the issue or the PR itself.
+
+* In GitHub, open a pull request to `lumo:master`.
+
+* If we suggest changes then:
+  * Make the required updates (please).
+  * Re-run the test suites to ensure tests are still passing.
+  * Rebase your branch if necessary and force push to your GitHub repository (this will update your PR).
+
+Thank you for your contribution!
+
+## Development workflow
+
+In order to start watch-compilation use:
+
+```shell
+boot dev
+```
+
+Then in another terminal execute the following for a plain dev REPL with autocaching:
+
+```shell
+yarn dev
+```
+
+Or this other command for a dev REPL that includes the test suite on the classpath:
+
+```shell
+yarn test-dev
+```
+
+The latter repl is useful for trying out failing tests individually:
+
+```clojure
+cljs.user=> (require 'lumo.repl-tests)
+nil
+cljs.user=> (in-ns 'lumo.repl-tests)
+lumo.repl-tests=> (t/test-var #'test-apropos)
+nil
+;; hopefully :)
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ test_script:
   - yarn test
   - cmd: boot test
   - cmd: boot release-ci
-  - cmd: build\lumo.exe -c src\test\cljs;src\test\lumo;src\test\cljs_cp -D org.clojure/test.check:0.10.0-alpha2 scripts\lumo_test.cljs --test-cli-option true
+  - cmd: scripts/test-build.bat
 
 artifacts:
   - path: build

--- a/circle.yml
+++ b/circle.yml
@@ -51,7 +51,7 @@ test:
     - yarn test
     - boot test
     - boot release-ci
-    - ./build/lumo -c src/test/cljs:src/test/lumo:src/test/cljs_cp -D org.clojure/test.check:0.10.0-alpha2 scripts/lumo_test.cljs --test-cli-option true
+    - ./scripts/test-build
   post:
     - chmod a+x build/lumo
     - zip -j build/lumo.zip build/lumo

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bundle": "node scripts/bundle.js --dev",
     "build": "cross-env NODE_ENV=production node scripts/bundle.js",
     "dev": "node target/bundle.js -k lumo-cache -c target",
+    "test-dev": "node target/bundle.js -k test-lumo-cache -c target:src/test/cljs:src/test/lumo:src/test/cljs_cp -D org.clojure/test.check:0.10.0-alpha",
     "postinstall": "opencollective postinstall"
   },
   "main": "./src/js/index.js",

--- a/packages/lumo/README.md
+++ b/packages/lumo/README.md
@@ -121,7 +121,7 @@ on Windows).
 
 ## Contributing
 
-Head to [CONTRIBUTING.md](https://raw.githubusercontent.com/anmonteiro/lumo/master/CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://raw.githubusercontent.com/anmonteiro/lumo/master/CONTRIBUTING.md).
 
 ## Backers
 

--- a/packages/lumo/README.md
+++ b/packages/lumo/README.md
@@ -119,6 +119,10 @@ To build Lumo from source:
 3. The resulting binary can be found in `build/lumo` (or `build\lumo.exe` if you're
 on Windows).
 
+## Contributing
+
+Head to [CONTRIBUTING.md](https://raw.githubusercontent.com/anmonteiro/lumo/master/CONTRIBUTING.md).
+
 ## Backers
 
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/lumo#backer)]

--- a/scripts/test-build
+++ b/scripts/test-build
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+./build/lumo -D org.clojure/test.check:0.10.0-alpha2 \
+  -c src/test/cljs:src/test/lumo:src/test/cljs_cp \
+  ./scripts/lumo_test.cljs --test-cli-option true

--- a/scripts/test-build.bat
+++ b/scripts/test-build.bat
@@ -1,0 +1,2 @@
+REM test the build artifact
+build\lumo.exe -c src\test\cljs;src\test\lumo;src\test\cljs_cp -D org.clojure/test.check:0.10.0-alpha2 scripts\lumo_test.cljs --test-cli-option true

--- a/src/test/lumo/lumo/build_api_tests.cljs
+++ b/src/test/lumo/lumo/build_api_tests.cljs
@@ -1,7 +1,7 @@
 (ns lumo.build-api-tests
   (:require-macros [cljs.env.macros :as env]
                    [cljs.analyzer.macros :as ana])
-  (:require [clojure.test :refer [deftest is testing async]]
+  (:require [clojure.test :as t :refer [deftest is testing async]]
             [cljs.env :as env]
             [cljs.analyzer :as ana]
             [lumo.io :refer [spit slurp]]

--- a/src/test/lumo/lumo/closure_tests.cljs
+++ b/src/test/lumo/lumo/closure_tests.cljs
@@ -1,5 +1,5 @@
 (ns lumo.closure-tests
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :as t :refer [deftest is testing]]
             [lumo.build.api :as build]
             [lumo.closure :as closure]
             [lumo.cljs-deps :as deps]

--- a/src/test/lumo/lumo/js_deps_tests.cljs
+++ b/src/test/lumo/lumo/js_deps_tests.cljs
@@ -1,5 +1,5 @@
 (ns lumo.js-deps-tests
-  (:require [cljs.test :refer [deftest is testing are]]
+  (:require [cljs.test :as t :refer [deftest is testing are]]
             [lumo.js-deps :as deps]))
 
 (deftest topo-sort-test

--- a/src/test/lumo/lumo/repl_tests.cljs
+++ b/src/test/lumo/lumo/repl_tests.cljs
@@ -1,6 +1,6 @@
 (ns lumo.repl-tests
   (:require [cljs.nodejs :as node]
-            [cljs.test :refer [deftest is testing use-fixtures]]
+            [cljs.test :as t :refer [deftest is testing use-fixtures]]
             [cljs.spec.alpha :as s]
             [lumo.repl :as lumo]
             [lumo.common :as common]

--- a/src/test/lumo/lumo/util_tests.cljs
+++ b/src/test/lumo/lumo/util_tests.cljs
@@ -1,5 +1,5 @@
 (ns lumo.util-tests
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :as t :refer [deftest testing is]]
             [lumo.util :as util]
             path))
 


### PR DESCRIPTION
This patch adds some explanation on how to contribute, what the dev workflow is
and how to execute tests.

It is meant to make it a bit easier for new contributors to start hacking.

For instance I added the `t/` alias for `cljs.test` and referred to it in the
CONTRIBUTING.md file so that there is less to type and I have create
`scripts/test-build` (and equivalent Windows script) for running easily against
the built artifact.