### PR TITLE
Use yauzl for unzipping npm content on install

### DIFF
--- a/packages/lumo/package.json
+++ b/packages/lumo/package.json
@@ -21,7 +21,7 @@
     "install": "node scripts/npm_install.js || nodejs scripts/npm_install.js"
   },
   "dependencies": {
-    "jszip": "2.6.1",
+    "yauzl": "2.9.1",
     "progress": "^2.0.0",
     "request": "2.81.0"
   },


### PR DESCRIPTION
This is allegedly fix the "Corrupted zip : can't find end of central directory"
that happens often while trying to `npm install -g lumo-cljs`.

As per Slack conversation, we cannot bump to latest `JSZip` because they dropped the sync API.
