### PR TITLE
Suppress yarn warnings by introducing babel-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "posix-getopt": "github:anmonteiro/node-getopt#master"
   },
   "devDependencies": {
+    "babel-core": "6.26.3",
     "babel-eslint": "8.2.3",
     "babel-jest": "22.4.3",
     "babel-plugin-external-helpers": "6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,7 +393,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@6.26.3, babel-core@^6.0.0, babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:


### PR DESCRIPTION
Without this patch I get:

```
[3/4] Linking dependencies...
warning " > babel-jest@22.4.3" has unmet peer dependency "babel-core@^6.0.0 || ^7.0.0-0".
warning " > rollup-plugin-babel@3.0.4" has unmet peer dependency "babel-core@6".
```