### PR TITLE
remove spurious comma

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -77,7 +77,7 @@ if (!isDevBuild) {
       comments: false,
       removeConsole: true,
       removeDebugger: true,
-    }),
+    })
   );
 }
 


### PR DESCRIPTION
I'm not able to reproduce this, but this comma seems to cause problems with some users on NixOs, at least one case here https://github.com/NixOS/nixpkgs/pull/44076, if this is really caused by this comma or not, I'm not sure, but it's the only explanation around this error:

```
/build/lumo-1.9.0-alpha/scripts/bundle.js:83
  );
  ^

SyntaxError: Unexpected token )
```