### PR TITLE
Update har-validator dependency to 5.1.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3598,9 +3598,9 @@ har-schema@^2.0.0:
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.2.tgz#a3891924f815c88e41c7f31112079cfef5e129e5"
-  integrity sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"


### PR DESCRIPTION
This change updates the `har-validator` dependency to `5.1.3` to enable Lumo to build successfully again.  It seems that `5.1.1` and `5.1.2` were [unpublished](https://github.com/ahmadnassri/node-har-validator/issues/112#issuecomment-437378269), causing the version stored in `yarn.lock` to no longer be installable.

Fixes #455.