### PR TITLE
Add BUILD_STATIC_BINARY env var for building a static lumo binary

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,6 +4,8 @@
 (def +node-version+ (or (System/getenv "BUILD_NODE_VERSION")
                         "11.13.0"))
 
+(def +build-static-binary+ (-> (System/getenv "BUILD_STATIC_BINARY") boolean str))
+
 (set-env!
  :source-paths #{"src/cljs/snapshot"}
  :asset-paths #{"src/js" "src/cljs/bundled"}
@@ -193,7 +195,7 @@
 (deftask package-executable
   [c ci-build bool "CI build"]
   (with-pass-thru _
-    (dosh "node" "scripts/package.js" +node-version+)))
+    (dosh "node" "scripts/package.js" +node-version+ +build-static-binary+)))
 
 (deftask backup-resources
   "Backup resources to be gzipped in the 2nd stage binary

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -9,6 +9,7 @@ const embed = require('./embed');
 
 const argv = process.argv.slice(0);
 const nodeVersion = argv[2];
+const staticBinary = /^true$/.test(argv[3]);
 
 function getDirContents(dir, accumPath = dir) {
   let filenames = fs.readdirSync(dir);
@@ -65,7 +66,8 @@ Promise.all(resources.map(deflate)).then(() => {
         '--without-inspector',
         '--without-etw',
         '--with-snapshot',
-      ].concat(isWindows ? ['--openssl-no-asm'] : []),
+      ]
+      .concat(isWindows ? ['--openssl-no-asm'] : (staticBinary ? ['--fully-static'] : [])),
       nodeMakeArgs: ['-j', '8'],
       nodeVCBuildArgs: ['nosign', 'x64', 'noetw'],
       flags: true,


### PR DESCRIPTION
A nice use case for the static binary is for building an AWS Custom Runtime,
see also https://github.com/grav/aws-lumo-cljs-runtime