### PR TITLE
Updating jszip dependency to point to apparent new repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "flow-bin": "0.98.1",
     "google-closure-compiler-js": "20170910.0.1",
     "jest-cli": "^24.7.0",
-    "jszip": "github:anmonteiro/jszip#patch-1",
+    "jszip": "github:Stuk/jszip#master",
     "nexe": "github:anmonteiro/nexe#anmonteiro-patch-1",
     "node-fetch": "^2.2.1",
     "paredit.js": "^0.3.4",


### PR DESCRIPTION
I'm not sure if master is the right head to point to in the new repo, but this seems to fix the bootstrap build.  Also, `boot test` passes with this change.

I believe the build error is why #502 happened